### PR TITLE
Fix null reference errors and improve error handling across cogs

### DIFF
--- a/cogs/invites/greetings_view.py
+++ b/cogs/invites/greetings_view.py
@@ -55,8 +55,11 @@ class PaginatorView(discord.ui.View):
     @discord.ui.button(label="Delete", style=ButtonStyle.red)
     async def delete_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         await self.delete_current_greeting(interaction)
-        if self.current_page == len(self.pages):
-            self.current_page -= 1
+        if not self.pages:
+            await interaction.response.edit_message(content="No greetings remaining.", embed=None, view=None)
+            return
+        if self.current_page >= len(self.pages):
+            self.current_page = len(self.pages) - 1
         await self.update_message(interaction)
 
     @discord.ui.button(label="Next", style=ButtonStyle.gray)

--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -99,8 +99,11 @@ class Invites(commands.Cog):
         for invite in recorded_invites:
             if invite['code'] not in [i.code for i in server_invites]:
                 inviter = member.guild.get_member(invite['author_id'])
-                print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter.name}")
-                inviter_id = inviter.id
+                if inviter is not None:
+                    print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter.name}")
+                    inviter_id = inviter.id
+                else:
+                    print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} (inviter no longer in server)")
                 await collection.delete_one({"code": invite['code']})
                 break
 
@@ -113,7 +116,7 @@ class Invites(commands.Cog):
             if announcement_channel is not None:
                 embed = discord.Embed(
                     title="Bienvenue!",
-                    thumbnail= member.avatar.url,
+                    thumbnail=member.display_avatar.url,
                     color=member.accent_color,
                     description=f"Bienvenue a <@{member.id}>, {f"invité.e par <@{inviter_id}>" if inviter_id is not None else ""} sur le discord de [Phoenix Legacy](https://phxlgc.com)!"
                 )

--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -44,6 +44,9 @@ class Invites(commands.Cog):
         await ctx.defer(ephemeral=True)
         collection: AsyncCollection[Greeting] = await self.bot.mongo.get_collection(ctx.guild_id, "greetings")
         greetings = await collection.find({}).to_list()
+        if not greetings:
+            await ctx.respond("No greetings in the database.")
+            return
         view = PaginatorView(self, greetings, id)
         await ctx.respond(
             content=view.get_content(),

--- a/cogs/quotes/quote_image.py
+++ b/cogs/quotes/quote_image.py
@@ -66,7 +66,8 @@ def _render(bg_data: bytes, quote: str, author: str, font_path: str) -> bytes:
 
 
 async def generate_quote_image(quote: str, author: str, font_path: str) -> bytes:
-    async with aiohttp.ClientSession() as session:
+    timeout = aiohttp.ClientTimeout(total=10)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.get(f'https://picsum.photos/{IMG_W}/{IMG_H}', allow_redirects=True) as resp:
             bg_data = await resp.read()
     return _render(bg_data, quote, author, font_path)

--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -84,6 +84,11 @@ class Topic(commands.Cog):
 
         collection: AsyncCollection[TopicEntry] = await self.bot.mongo.get_collection(ctx.guild_id, "topics")
         topic = await collection.find_one(filter={"roleId": str(role.id)})
+
+        if topic is None:
+            await ctx.respond("Topic not found in the database.")
+            return
+
         type_descriptor = topic_types[topic_type]
         color = discord.Color(int(type_descriptor["color"], 16))
 
@@ -130,9 +135,11 @@ class Topic(commands.Cog):
             await ctx.respond("Topic not found in the database, you might need to delete this one manually")
             return
 
-        message = await ctx.fetch_message(int(topic["messageId"]))
+        channel = self.bot.get_channel(int(topic["channelId"]))
+        message = await channel.fetch_message(int(topic["messageId"]))
         await message.delete()
         await role.delete()
+        await collection.delete_one({"_id": topic["_id"]})
         await ctx.respond("Removed topic successfully!")
 
     @commands.Cog.listener()

--- a/main.py
+++ b/main.py
@@ -10,7 +10,8 @@ bot = FriendlyFire(mongo_uri=MONGO_URI)
 
 # load all cogs as extensions
 for cog in os.listdir('./cogs'):
-    bot.load_extension(f'cogs.{cog}.{cog}')
+    if os.path.isdir(os.path.join('./cogs', cog)):
+        bot.load_extension(f'cogs.{cog}.{cog}')
 
 # start the bot
 bot.run(TOKEN)

--- a/src/mongo.py
+++ b/src/mongo.py
@@ -10,9 +10,4 @@ class Mongo:
 
     async def get_collection(self, guild_id: int, collection_name: str):
         database = self.client.get_database(str(guild_id))
-        collection = database[collection_name]
-
-        if collection is None:
-            collection = await database.create_collection(collection_name)
-
-        return collection
+        return database[collection_name]


### PR DESCRIPTION
## Summary
This PR addresses several null reference bugs and improves error handling across multiple cogs and utility modules. The changes focus on defensive programming practices to prevent crashes when expected objects are unavailable.

## Key Changes

- **Invites cog**: Added null check for inviter before accessing their properties; gracefully handles cases where the inviter has left the server
- **Invites cog**: Updated deprecated `member.avatar.url` to `member.display_avatar.url`
- **Topic cog**: Added null check in `edit_topic` to handle missing topics in database
- **Topic cog**: Fixed `delete_topic` to fetch message from correct channel and properly clean up database entry
- **Greetings view**: Fixed pagination logic when deleting greetings to prevent index out of bounds errors
- **Mongo utility**: Simplified `get_collection` by removing unnecessary null check (MongoDB creates collections on first write)
- **Quote image generator**: Added timeout configuration to aiohttp session to prevent hanging requests
- **Main bot loader**: Added directory check before attempting to load cogs to prevent errors from non-directory files

## Notable Implementation Details

- The inviter null check in the invites cog now logs a different message when the inviter is no longer in the server, maintaining audit trail visibility
- The greetings view now checks if pages list is empty before attempting pagination, and uses safer index bounds checking
- The topic deletion now properly retrieves the channel before fetching the message, preventing potential channel lookup failures

https://claude.ai/code/session_01TC9a3SnMdLfaU6HE72Zk2k