### PR TITLE
fix: resolve crashes and logic errors across bot, invites, topic, and quote image

### DIFF
--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -99,8 +99,12 @@ class Invites(commands.Cog):
         for invite in recorded_invites:
             if invite['code'] not in [i.code for i in server_invites]:
                 inviter = member.guild.get_member(invite['author_id'])
-                print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter.name}")
-                inviter_id = inviter.id
+                if inviter is not None:
+                    print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter.name}")
+                    inviter_id = inviter.id
+                else:
+                    print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} (inviter has left the server)")
+                    inviter_id = invite['author_id']
                 await collection.delete_one({"code": invite['code']})
                 break
 
@@ -113,7 +117,7 @@ class Invites(commands.Cog):
             if announcement_channel is not None:
                 embed = discord.Embed(
                     title="Bienvenue!",
-                    thumbnail= member.avatar.url,
+                    thumbnail=member.display_avatar.url,
                     color=member.accent_color,
                     description=f"Bienvenue a <@{member.id}>, {f"invité.e par <@{inviter_id}>" if inviter_id is not None else ""} sur le discord de [Phoenix Legacy](https://phxlgc.com)!"
                 )

--- a/cogs/quotes/quote_image.py
+++ b/cogs/quotes/quote_image.py
@@ -68,5 +68,6 @@ def _render(bg_data: bytes, quote: str, author: str, font_path: str) -> bytes:
 async def generate_quote_image(quote: str, author: str, font_path: str) -> bytes:
     async with aiohttp.ClientSession() as session:
         async with session.get(f'https://picsum.photos/{IMG_W}/{IMG_H}', allow_redirects=True) as resp:
+            resp.raise_for_status()
             bg_data = await resp.read()
     return _render(bg_data, quote, author, font_path)

--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -88,6 +88,9 @@ class Topic(commands.Cog):
         color = discord.Color(int(type_descriptor["color"], 16))
 
         channel = self.bot.get_channel(int(topic["channelId"]))
+        if channel is None:
+            await ctx.respond("Could not find the topic's channel. It may have been deleted.")
+            return
         message = await channel.fetch_message(int(topic["messageId"]))
         prev_embed = message.embeds[0]
 
@@ -130,28 +133,38 @@ class Topic(commands.Cog):
             await ctx.respond("Topic not found in the database, you might need to delete this one manually")
             return
 
-        message = await ctx.fetch_message(int(topic["messageId"]))
+        message = await ctx.channel.fetch_message(int(topic["messageId"]))
         await message.delete()
         await role.delete()
         await ctx.respond("Removed topic successfully!")
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        if str(payload.emoji) != '✅':
+            return
         collection: AsyncCollection[TopicEntry] = await self.bot.mongo.get_collection(payload.guild_id, "topics")
         topic = await collection.find_one(filter={"messageId": str(payload.message_id)})
         if topic:
             guild = self.bot.get_guild(payload.guild_id)
             role = guild.get_role(int(topic["roleId"]))
+            if role is None:
+                print(f"[Topic] Role {topic['roleId']} not found, skipping reaction.")
+                return
             await payload.member.add_roles(role)
             print(f"Added role {role.name} to user {payload.member.name}")
 
     @commands.Cog.listener()
     async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
+        if str(payload.emoji) != '✅':
+            return
         collection: AsyncCollection[TopicEntry] = await self.bot.mongo.get_collection(payload.guild_id, "topics")
         topic = await collection.find_one(filter={"messageId": str(payload.message_id)})
         if topic:
             guild = self.bot.get_guild(payload.guild_id)
             role = guild.get_role(int(topic["roleId"]))
+            if role is None:
+                print(f"[Topic] Role {topic['roleId']} not found, skipping reaction.")
+                return
             member = await guild.fetch_member(payload.user_id)
             await member.remove_roles(role)
             print(f"Removed role {role.name} from user {member.name}")

--- a/src/bot.py
+++ b/src/bot.py
@@ -3,10 +3,11 @@ from discord.ext import commands
 from src.mongo import Mongo
 
 class FriendlyFire(commands.Bot):
-    intents = discord.Intents.default()
-
     def __init__(self, mongo_uri: str = None):
-        super().__init__()
+        intents = discord.Intents.default()
+        intents.members = True          # required for on_member_join
+        intents.message_content = True  # required for on_message quote capture
+        super().__init__(intents=intents)
         self.mongo = Mongo(mongo_uri)
 
     async def on_ready(self):


### PR DESCRIPTION
## Summary

Automated code review found 7 real, crash-producing bugs. All fixes are minimal and surgical — no refactoring or style changes.

### `src/bot.py`
- The `intents` class attribute was never passed to `super().__init__()`, so the bot was starting with no intents configured. Fixed by moving to a local variable and passing it explicitly.
- Added `members = True` (required by `on_member_join` in the invites cog) and `message_content = True` (required by `on_message` quote capture) privileged intents. Without these, member-join events and message content are silently dropped by Discord.

### `cogs/invites/invites.py`
- **`AttributeError` crash**: `member.guild.get_member(invite['author_id'])` returns `None` when the inviting user has since left the guild. The next lines immediately accessed `.name` and `.id` on that `None`, crashing `on_member_join` for any join where the inviter had left. Now guards with an `if inviter is not None` branch.
- **`AttributeError` crash**: `member.avatar.url` crashes for members with no custom avatar (`.avatar` is `None`). Changed to `member.display_avatar.url`, which always resolves to a valid URL.

### `cogs/topic/topic.py`
- **`AttributeError` crash in `delete_topic`**: `ctx.fetch_message()` was called on an `ApplicationContext`, which has no such method. Fixed to `ctx.channel.fetch_message()`.
- **`AttributeError` crash in `edit_topic`**: `self.bot.get_channel()` returns `None` if the original topic channel was deleted. Now returns early with an error message instead of crashing on `.fetch_message()`.
- **Wrong behavior + potential crash in reaction handlers**: Both `on_raw_reaction_add` and `on_raw_reaction_remove` were triggering on *any* reaction to a topic message (👍, 😂, etc.), not just ✅. This incorrectly assigned/removed roles for unrelated reactions. Added an early return for non-✅ emojis. Also added a `None` guard on the fetched role (in case the Discord role was deleted without removing the DB entry), preventing a silent crash in `add_roles`/`remove_roles`.

### `cogs/quotes/quote_image.py`
- No HTTP status check on the request to `picsum.photos`. A 4xx/5xx response would pass the error-page HTML body to PIL's `Image.open()`, producing a cryptic `UnidentifiedImageError` with no indication the external service failed. Added `resp.raise_for_status()`.

## Test plan
- [ ] Bot starts without `TypeError` about missing intents
- [ ] Member joins with a known invite code where the inviter has left the server — no crash, `inviter_id` falls back to the stored author ID
- [ ] Member with no custom avatar joins — welcome embed sends without crash
- [ ] `/topic delete` on a topic whose message channel still exists — message deleted cleanly
- [ ] `/topic edit` on a topic whose channel was deleted — responds with error message, no crash
- [ ] Reacting with a non-✅ emoji on a topic message — no role change triggered
- [ ] Reacting ✅ when the backing role was deleted — logs warning, no crash
- [ ] `/quote` when picsum.photos returns non-200 — raises `ClientResponseError` with a clear HTTP status instead of cryptic PIL error

https://claude.ai/code/session_01KZE47bwjpQKZ8dE6QNGcnw