### PR TITLE
fix: resolve crash-level bugs in invites, topic, and quotes cogs

### DIFF
--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -74,6 +74,9 @@ class Invites(commands.Cog):
     async def test_join(self, ctx: discord.ApplicationContext, user: discord.User):
         await ctx.defer(ephemeral=True)
         member = ctx.guild.get_member(user.id)
+        if member is None:
+            await ctx.respond("User is not a member of this guild.")
+            return
         await self.on_member_join(member)
         await ctx.respond("test_join succeeded!")
 
@@ -99,8 +102,9 @@ class Invites(commands.Cog):
         for invite in recorded_invites:
             if invite['code'] not in [i.code for i in server_invites]:
                 inviter = member.guild.get_member(invite['author_id'])
-                print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter.name}")
-                inviter_id = inviter.id
+                inviter_name = inviter.name if inviter is not None else f"unknown user ({invite['author_id']})"
+                print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter_name}")
+                inviter_id = invite['author_id']
                 await collection.delete_one({"code": invite['code']})
                 break
 
@@ -113,7 +117,7 @@ class Invites(commands.Cog):
             if announcement_channel is not None:
                 embed = discord.Embed(
                     title="Bienvenue!",
-                    thumbnail= member.avatar.url,
+                    thumbnail=member.display_avatar.url,
                     color=member.accent_color,
                     description=f"Bienvenue a <@{member.id}>, {f"invité.e par <@{inviter_id}>" if inviter_id is not None else ""} sur le discord de [Phoenix Legacy](https://phxlgc.com)!"
                 )

--- a/cogs/quotes/quote_image.py
+++ b/cogs/quotes/quote_image.py
@@ -67,6 +67,6 @@ def _render(bg_data: bytes, quote: str, author: str, font_path: str) -> bytes:
 
 async def generate_quote_image(quote: str, author: str, font_path: str) -> bytes:
     async with aiohttp.ClientSession() as session:
-        async with session.get(f'https://picsum.photos/{IMG_W}/{IMG_H}', allow_redirects=True) as resp:
+        async with session.get(f'https://picsum.photos/{IMG_W}/{IMG_H}', allow_redirects=True, timeout=aiohttp.ClientTimeout(total=10)) as resp:
             bg_data = await resp.read()
     return _render(bg_data, quote, author, font_path)

--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -87,7 +87,7 @@ class Topic(commands.Cog):
         type_descriptor = topic_types[topic_type]
         color = discord.Color(int(type_descriptor["color"], 16))
 
-        channel = self.bot.get_channel(int(topic["channelId"]))
+        channel = self.bot.get_channel(int(topic["channelId"])) or await self.bot.fetch_channel(int(topic["channelId"]))
         message = await channel.fetch_message(int(topic["messageId"]))
         prev_embed = message.embeds[0]
 
@@ -130,7 +130,8 @@ class Topic(commands.Cog):
             await ctx.respond("Topic not found in the database, you might need to delete this one manually")
             return
 
-        message = await ctx.fetch_message(int(topic["messageId"]))
+        channel = self.bot.get_channel(int(topic["channelId"])) or await self.bot.fetch_channel(int(topic["channelId"]))
+        message = await channel.fetch_message(int(topic["messageId"]))
         await message.delete()
         await role.delete()
         await ctx.respond("Removed topic successfully!")
@@ -142,6 +143,9 @@ class Topic(commands.Cog):
         if topic:
             guild = self.bot.get_guild(payload.guild_id)
             role = guild.get_role(int(topic["roleId"]))
+            if role is None:
+                print(f"Role {topic['roleId']} not found, skipping reaction add.")
+                return
             await payload.member.add_roles(role)
             print(f"Added role {role.name} to user {payload.member.name}")
 
@@ -152,6 +156,9 @@ class Topic(commands.Cog):
         if topic:
             guild = self.bot.get_guild(payload.guild_id)
             role = guild.get_role(int(topic["roleId"]))
+            if role is None:
+                print(f"Role {topic['roleId']} not found, skipping reaction remove.")
+                return
             member = await guild.fetch_member(payload.user_id)
             await member.remove_roles(role)
             print(f"Removed role {role.name} from user {member.name}")


### PR DESCRIPTION
## Summary

Automated code review (2026-04-14) found several places where the bot would crash with `AttributeError` or `TypeError` at runtime due to unchecked `None` returns from Discord API cache lookups and a missing HTTP timeout. All changes are minimal targeted fixes with no functional or behavioural changes beyond the crash paths.

### `cogs/invites/invites.py`

- **`on_member_join` — inviter lookup** (`inviter.name` crash): `guild.get_member()` returns `None` when the inviter has since left the server. The code unconditionally accessed `.name` and `.id` on the result. Fixed by guarding with a `None` check and reading `invite['author_id']` directly for the ID.
- **`on_member_join` — member avatar** (`member.avatar.url` crash): `member.avatar` is `None` for members using Discord's default avatar. Replaced with `member.display_avatar.url`, which always resolves to a valid URL.
- **`/test_join` — missing member guard**: `ctx.guild.get_member()` can return `None` if the target user is not currently in the guild. Added an early-return with an error response before passing the result to `on_member_join`.

### `cogs/topic/topic.py`

- **`edit_topic` — `get_channel()` returning `None`**: `bot.get_channel()` only hits the in-memory cache and returns `None` for channels the bot hasn't observed since startup. The subsequent `.fetch_message()` call would then crash. Fixed with `get_channel() or await fetch_channel()` fallback.
- **`delete_topic` — wrong channel for `fetch_message`**: The command used `ctx.fetch_message()`, which looks up a message ID in the *command invocation channel*, not the topic's own channel. This would silently fail or delete the wrong message. Fixed to resolve the topic's channel first (same cache+fetch pattern) then fetch the message from there.
- **Reaction handlers — `get_role()` returning `None`**: `guild.get_role()` returns `None` when a role has been deleted outside the bot. Calling `add_roles(None)` / `remove_roles(None)` raises `TypeError`. Added a guard with a warning log in both `on_raw_reaction_add` and `on_raw_reaction_remove`.

### `cogs/quotes/quote_image.py`

- **Missing HTTP timeout on background image fetch**: The `aiohttp` request to `picsum.photos` had no timeout, so a slow or unresponsive server would leave the coroutine (and the slash command that triggered it) hanging indefinitely. Added `aiohttp.ClientTimeout(total=10)`.

## Test plan

- [ ] Trigger `/invite` then have the inviter leave the server before someone uses the link — confirm join event is handled gracefully
- [ ] Trigger a member join for a user with no custom avatar — confirm welcome embed is sent without error
- [ ] Run `/test_join` with a user not in the guild — confirm the bot responds with an error instead of crashing
- [ ] Run `/topic edit` and `/topic delete` in a guild where the bot has just restarted (cold cache) — confirm the commands complete successfully
- [ ] Delete a topic role manually, then react to its message — confirm the bot logs a warning instead of crashing
- [ ] Run `/quote` — confirm the image is generated within 10 seconds or fails gracefully on timeout

https://claude.ai/code/session_0176PRdajnjVpofeVHyFrS8G