### PR TITLE
fix: resolve crash bugs found in automated code review

### DIFF
--- a/cogs/invites/greetings_view.py
+++ b/cogs/invites/greetings_view.py
@@ -55,8 +55,12 @@ class PaginatorView(discord.ui.View):
     @discord.ui.button(label="Delete", style=ButtonStyle.red)
     async def delete_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         await self.delete_current_greeting(interaction)
-        if self.current_page == len(self.pages):
-            self.current_page -= 1
+        if not self.pages:
+            self.disable_all_items()
+            await interaction.response.edit_message(content="No greetings left.", embed=None, view=self)
+            return
+        if self.current_page >= len(self.pages):
+            self.current_page = len(self.pages) - 1
         await self.update_message(interaction)
 
     @discord.ui.button(label="Next", style=ButtonStyle.gray)

--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -99,8 +99,11 @@ class Invites(commands.Cog):
         for invite in recorded_invites:
             if invite['code'] not in [i.code for i in server_invites]:
                 inviter = member.guild.get_member(invite['author_id'])
-                print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter.name}")
-                inviter_id = inviter.id
+                if inviter is not None:
+                    print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter.name}")
+                    inviter_id = inviter.id
+                else:
+                    print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} (inviter no longer in guild)")
                 await collection.delete_one({"code": invite['code']})
                 break
 
@@ -113,7 +116,7 @@ class Invites(commands.Cog):
             if announcement_channel is not None:
                 embed = discord.Embed(
                     title="Bienvenue!",
-                    thumbnail= member.avatar.url,
+                    thumbnail=member.display_avatar.url,
                     color=member.accent_color,
                     description=f"Bienvenue a <@{member.id}>, {f"invité.e par <@{inviter_id}>" if inviter_id is not None else ""} sur le discord de [Phoenix Legacy](https://phxlgc.com)!"
                 )

--- a/cogs/quotes/quote_image.py
+++ b/cogs/quotes/quote_image.py
@@ -66,7 +66,8 @@ def _render(bg_data: bytes, quote: str, author: str, font_path: str) -> bytes:
 
 
 async def generate_quote_image(quote: str, author: str, font_path: str) -> bytes:
-    async with aiohttp.ClientSession() as session:
+    timeout = aiohttp.ClientTimeout(total=10)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.get(f'https://picsum.photos/{IMG_W}/{IMG_H}', allow_redirects=True) as resp:
             bg_data = await resp.read()
     return _render(bg_data, quote, author, font_path)

--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -84,10 +84,17 @@ class Topic(commands.Cog):
 
         collection: AsyncCollection[TopicEntry] = await self.bot.mongo.get_collection(ctx.guild_id, "topics")
         topic = await collection.find_one(filter={"roleId": str(role.id)})
+        if topic is None:
+            await ctx.respond("Topic not found in the database.")
+            return
+
         type_descriptor = topic_types[topic_type]
         color = discord.Color(int(type_descriptor["color"], 16))
 
         channel = self.bot.get_channel(int(topic["channelId"]))
+        if channel is None:
+            await ctx.respond("Topic channel not found — it may have been deleted.")
+            return
         message = await channel.fetch_message(int(topic["messageId"]))
         prev_embed = message.embeds[0]
 
@@ -130,9 +137,15 @@ class Topic(commands.Cog):
             await ctx.respond("Topic not found in the database, you might need to delete this one manually")
             return
 
-        message = await ctx.fetch_message(int(topic["messageId"]))
-        await message.delete()
+        channel = self.bot.get_channel(int(topic["channelId"]))
+        if channel is not None:
+            try:
+                message = await channel.fetch_message(int(topic["messageId"]))
+                await message.delete()
+            except discord.NotFound:
+                pass
         await role.delete()
+        await collection.delete_one({"_id": topic["_id"]})
         await ctx.respond("Removed topic successfully!")
 
     @commands.Cog.listener()

--- a/src/config.py
+++ b/src/config.py
@@ -53,3 +53,6 @@ class Config:
             template_hint = f' See {self.template_file} for reference.' if os.path.exists(self.template_file) else ''
             print(f'[Config] {self.config_file} not found, using defaults.{template_hint}')
             return {}
+        except json.JSONDecodeError as e:
+            print(f'[Config] {self.config_file} is malformed ({e}), using defaults.')
+            return {}

--- a/src/mongo.py
+++ b/src/mongo.py
@@ -1,5 +1,4 @@
-﻿import asyncio
-from pymongo import AsyncMongoClient
+﻿from pymongo import AsyncMongoClient
 from pymongo.asynchronous.collection import AsyncCollection
 
 
@@ -10,9 +9,4 @@ class Mongo:
 
     async def get_collection(self, guild_id: int, collection_name: str):
         database = self.client.get_database(str(guild_id))
-        collection = database[collection_name]
-
-        if collection is None:
-            collection = await database.create_collection(collection_name)
-
-        return collection
+        return database[collection_name]


### PR DESCRIPTION
## Summary

Automated code review found 8 real, reproducible bugs across 6 files. All changes are pure bug fixes with no behavioural changes beyond preventing crashes.

### Bugs fixed

**`cogs/invites/invites.py`**
- `on_member_join`: `guild.get_member()` returns `None` when the inviter has since left the guild. Accessing `.name` / `.id` on `None` raised `AttributeError` and aborted the entire join handler (role assignment + announcement never ran). Now logs the invite use and continues gracefully.
- `on_member_join`: `member.avatar` is `None` for users who have never set a custom avatar. Using `.url` on `None` crashed the announcement embed. Replaced with `member.display_avatar.url`, which always returns a valid URL (falls back to the default avatar).

**`cogs/topic/topic.py`**
- `edit_topic`: `collection.find_one()` returns `None` when no matching topic exists for the role. Indexing into `None` raised `TypeError`. Added an early-exit guard with a user-facing error message.
- `edit_topic`: `bot.get_channel()` returns `None` when the topic channel has been deleted. Calling `.fetch_message()` on `None` raised `AttributeError`. Added a `None` check with a user-facing error.
- `delete_topic`: used `ctx.fetch_message()` which fetches from the *interaction's* channel, not the channel where the topic embed was posted. This raised `discord.NotFound` whenever the command was run from a different channel. Fixed to fetch from the stored `channelId`. Also: the MongoDB document was never deleted, leaking a stale entry on every successful deletion. Added `collection.delete_one()` to clean up.

**`cogs/invites/greetings_view.py`**
- `delete_button`: after removing the last greeting, `self.pages` is empty. The original code set `self.current_page = -1`, then called `get_embed()` which did `self.pages[-1]` — `IndexError` on an empty list. Now detects the empty state, disables all buttons, and shows a "No greetings left." message instead.

**`cogs/quotes/quote_image.py`**
- `generate_quote_image`: the HTTP request to `picsum.photos` had no timeout. A slow or unreachable server would block the coroutine indefinitely, hanging the bot's event loop. Added a 10-second `aiohttp.ClientTimeout`.

**`src/config.py`**
- `load`: only `FileNotFoundError` was caught. A malformed JSON config file raised an unhandled `json.JSONDecodeError`, crashing bot startup. Added a handler that logs the parse error and falls back to defaults.

**`src/mongo.py`**
- Removed unused `import asyncio`.
- Removed dead `if collection is None` branch: `database[name]` in pymongo always returns a `Collection` object and never `None`, so the branch never executed.

## Test plan
- [ ] Trigger `on_member_join` with an invite whose author has left the server — confirm no crash and announcement still sends
- [ ] Trigger `on_member_join` for a user with no custom avatar — confirm embed sends
- [ ] Run `/topic edit` on a role with no DB entry — confirm graceful error message
- [ ] Run `/topic delete` from a channel different from the topic channel — confirm message is deleted and DB entry is removed
- [ ] Delete the last greeting in the paginator — confirm "No greetings left." message, no crash
- [ ] Run `/quote` with picsum.photos unreachable (e.g. blocked at firewall) — confirm 10 s timeout rather than hang
- [ ] Write invalid JSON to a config file and restart — confirm bot starts with defaults instead of crashing

https://claude.ai/code/session_01PVnosSeAUBpmeHMwJSYnGs