### PR TITLE
fix: resolve crashes and logic errors across multiple cogs

### DIFF
--- a/cogs/invites/greetings_view.py
+++ b/cogs/invites/greetings_view.py
@@ -55,8 +55,12 @@ class PaginatorView(discord.ui.View):
     @discord.ui.button(label="Delete", style=ButtonStyle.red)
     async def delete_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         await self.delete_current_greeting(interaction)
-        if self.current_page == len(self.pages):
-            self.current_page -= 1
+        if not self.pages:
+            await interaction.response.edit_message(content="No greetings left.", embed=None, view=None)
+            self.stop()
+            return
+        if self.current_page >= len(self.pages):
+            self.current_page = len(self.pages) - 1
         await self.update_message(interaction)
 
     @discord.ui.button(label="Next", style=ButtonStyle.gray)

--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -99,8 +99,9 @@ class Invites(commands.Cog):
         for invite in recorded_invites:
             if invite['code'] not in [i.code for i in server_invites]:
                 inviter = member.guild.get_member(invite['author_id'])
-                print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter.name}")
-                inviter_id = inviter.id
+                inviter_name = inviter.name if inviter is not None else f"(id={invite['author_id']})"
+                print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter_name}")
+                inviter_id = invite['author_id']
                 await collection.delete_one({"code": invite['code']})
                 break
 
@@ -113,7 +114,7 @@ class Invites(commands.Cog):
             if announcement_channel is not None:
                 embed = discord.Embed(
                     title="Bienvenue!",
-                    thumbnail= member.avatar.url,
+                    thumbnail=member.display_avatar.url,
                     color=member.accent_color,
                     description=f"Bienvenue a <@{member.id}>, {f"invité.e par <@{inviter_id}>" if inviter_id is not None else ""} sur le discord de [Phoenix Legacy](https://phxlgc.com)!"
                 )

--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -130,29 +130,47 @@ class Topic(commands.Cog):
             await ctx.respond("Topic not found in the database, you might need to delete this one manually")
             return
 
-        message = await ctx.fetch_message(int(topic["messageId"]))
-        await message.delete()
+        channel = self.bot.get_channel(int(topic["channelId"]))
+        if channel is not None:
+            try:
+                message = await channel.fetch_message(int(topic["messageId"]))
+                await message.delete()
+            except discord.NotFound:
+                pass
         await role.delete()
+        await collection.delete_one({"_id": topic["_id"]})
         await ctx.respond("Removed topic successfully!")
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        if payload.member is None or payload.member.bot:
+            return
+        if str(payload.emoji) != "✅":
+            return
         collection: AsyncCollection[TopicEntry] = await self.bot.mongo.get_collection(payload.guild_id, "topics")
         topic = await collection.find_one(filter={"messageId": str(payload.message_id)})
         if topic:
             guild = self.bot.get_guild(payload.guild_id)
             role = guild.get_role(int(topic["roleId"]))
+            if role is None:
+                return
             await payload.member.add_roles(role)
             print(f"Added role {role.name} to user {payload.member.name}")
 
     @commands.Cog.listener()
     async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
+        if str(payload.emoji) != "✅":
+            return
         collection: AsyncCollection[TopicEntry] = await self.bot.mongo.get_collection(payload.guild_id, "topics")
         topic = await collection.find_one(filter={"messageId": str(payload.message_id)})
         if topic:
             guild = self.bot.get_guild(payload.guild_id)
             role = guild.get_role(int(topic["roleId"]))
+            if role is None:
+                return
             member = await guild.fetch_member(payload.user_id)
+            if member.bot:
+                return
             await member.remove_roles(role)
             print(f"Removed role {role.name} from user {member.name}")
 

--- a/main.py
+++ b/main.py
@@ -10,6 +10,8 @@ bot = FriendlyFire(mongo_uri=MONGO_URI)
 
 # load all cogs as extensions
 for cog in os.listdir('./cogs'):
+    if not os.path.isdir(f'./cogs/{cog}') or cog.startswith('_'):
+        continue
     bot.load_extension(f'cogs.{cog}.{cog}')
 
 # start the bot

--- a/src/bot.py
+++ b/src/bot.py
@@ -3,10 +3,11 @@ from discord.ext import commands
 from src.mongo import Mongo
 
 class FriendlyFire(commands.Bot):
-    intents = discord.Intents.default()
-
     def __init__(self, mongo_uri: str = None):
-        super().__init__()
+        intents = discord.Intents.default()
+        intents.members = True          # required for on_member_join
+        intents.message_content = True  # required for reading message content (quotes)
+        super().__init__(intents=intents)
         self.mongo = Mongo(mongo_uri)
 
     async def on_ready(self):

--- a/src/mongo.py
+++ b/src/mongo.py
@@ -10,9 +10,4 @@ class Mongo:
 
     async def get_collection(self, guild_id: int, collection_name: str):
         database = self.client.get_database(str(guild_id))
-        collection = database[collection_name]
-
-        if collection is None:
-            collection = await database.create_collection(collection_name)
-
-        return collection
+        return database[collection_name]


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Automated code review found 9 real bugs — crashes and silent misbehaviours across 6 files. All are fixed in this PR.

---

### `src/bot.py` — Missing privileged intents (breaking)
`discord.Intents.default()` does not include `members` or `message_content`. Without these:
- `on_member_join` is never fired → invite tracking and welcome messages silently do nothing
- Message content is unreadable → quote capture never fires

**Fix:** enable `intents.members` and `intents.message_content` at bot construction.

---

### `main.py` — Cog loader crashes on `__pycache__`
`os.listdir('./cogs')` returns every entry including `__pycache__`, causing `bot.load_extension('cogs.__pycache__.__pycache__')` to raise on startup.

**Fix:** skip entries that are not directories or start with `_`.

---

### `cogs/invites/invites.py` — Two NoneType crashes in `on_member_join`
1. `member.guild.get_member(invite['author_id'])` returns `None` when the inviter has left the guild. The next line unconditionally calls `.name` and `.id` on the result → `AttributeError`.
2. `member.avatar.url` crashes for members using the default Discord avatar (`member.avatar` is `None`).

**Fix:** null-check the inviter and fall back to the stored `author_id`; use `member.display_avatar.url` which is always non-None.

---

### `cogs/invites/greetings_view.py` — Crash after deleting last greeting
After deleting the final page `self.pages` becomes empty, but the code still calls `self.get_embed()` → `IndexError`.

**Fix:** detect the empty-list case, send a "No greetings left" message, and stop the view.

---

### `cogs/topic/topic.py` — Four bugs

| # | Bug | Fix |
|---|-----|-----|
| 1 | `delete_topic` calls `ctx.fetch_message()` which fetches from the **command channel**, not the topic's channel | Fetch via the stored `channelId`, matching what `edit_topic` already does |
| 2 | `delete_topic` deletes the Discord role and message but **never removes the DB document**, so stale reactions keep hitting dead roles | Call `collection.delete_one` after deletion |
| 3 | `on_raw_reaction_add/remove` fires for **any emoji**, not just ✅ — any reaction subscribes the user | Guard with `str(payload.emoji) != "✅"` |
| 4 | `guild.get_role()` returns `None` for deleted roles; passing it to `add_roles/remove_roles` crashes | Early-return when `role is None` |

Bot reactions (when adding ✅ after topic creation) are also now filtered out via `payload.member.bot` checks.

---

### `src/mongo.py` — Dead/broken code removed
`database[collection_name]` never returns `None` in pymongo — the null-check branch was unreachable, and `create_collection` on an existing collection raises `CollectionInvalid`. Removed the dead block.

## Test plan
- [ ] Bot starts without errors (no `__pycache__` load attempt)
- [ ] `on_member_join` fires correctly with the `members` intent enabled
- [ ] Quote capture works with `message_content` intent enabled
- [ ] Joining via an invite from a user who has since left the guild does not crash
- [ ] Joining with a default (non-custom) avatar does not crash
- [ ] Deleting the last greeting via the paginator shows "No greetings left" instead of crashing
- [ ] `/topic delete` removes the embed from the correct channel and removes the DB record
- [ ] Reacting with a non-✅ emoji on a topic message does not assign a role
- [ ] Bot adding ✅ after topic creation does not attempt to assign the role to itself

https://claude.ai/code/session_011PSzeoHWr1TAYcPX1QngCD
EOF
)