### PR TITLE
fix: handle deleted reply channel in /quote command

### DIFF
--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -82,7 +82,12 @@ class Quotes(commands.Cog):
     @discord.option(name="id", parameter_name="quote_id", description="Id of the quote to send", required=False, input_type=int)
     async def quote(self, ctx: discord.ApplicationContext, quote_id: int = None):
         reply_channel_id = self.config.get('replyChannelId', ctx.guild_id)
-        reply_channel = await self.bot.fetch_channel(int(reply_channel_id)) if reply_channel_id else None
+        reply_channel = None
+        if reply_channel_id:
+            try:
+                reply_channel = await self.bot.fetch_channel(int(reply_channel_id))
+            except discord.NotFound:
+                pass
         use_reply_channel = reply_channel is not None and reply_channel.id != ctx.channel_id
 
         await ctx.defer(ephemeral=use_reply_channel)


### PR DESCRIPTION
## Summary

- `fetch_channel` raises `discord.NotFound` when the configured reply channel has been deleted, causing `/quote` to crash with no response to the user (Discord shows "Application did not respond").
- Wrap the call in a `try/except discord.NotFound` block so the command falls back to responding in the invocation channel instead.

Fixes #11

## Test plan

- [ ] Configure a reply channel with `/quotes set-reply-channel`, then delete that channel from Discord and run `/quote` — confirm the bot responds in the current channel without crashing
- [ ] With a valid reply channel, confirm `/quote` still sends to the reply channel as expected

https://claude.ai/code/session_01UbxBfrLjhiYgdeCDzx7a2q

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbxBfrLjhiYgdeCDzx7a2q)_