### PR TITLE
fix: pass intents to bot and guard cog loader against non-directories

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,8 @@ bot = FriendlyFire(mongo_uri=MONGO_URI)
 
 # load all cogs as extensions
 for cog in os.listdir('./cogs'):
+    if not os.path.isdir(f'./cogs/{cog}') or cog.startswith('_'):
+        continue
     bot.load_extension(f'cogs.{cog}.{cog}')
 
 # start the bot

--- a/src/bot.py
+++ b/src/bot.py
@@ -3,10 +3,11 @@ from discord.ext import commands
 from src.mongo import Mongo
 
 class FriendlyFire(commands.Bot):
-    intents = discord.Intents.default()
-
     def __init__(self, mongo_uri: str = None):
-        super().__init__()
+        intents = discord.Intents.default()
+        intents.members = True
+        intents.message_content = True
+        super().__init__(intents=intents)
         self.mongo = Mongo(mongo_uri)
 
     async def on_ready(self):


### PR DESCRIPTION
## Summary

Two bugs that prevent the bot from starting or functioning correctly.

### `src/bot.py` — intents never applied (breaking)

`discord.Intents.default()` was stored as a class variable but never passed to `super().__init__()`, so the bot started with **no intents at all**. Additionally, the two privileged intents the cogs depend on were missing:

- `members = True` — required for `on_member_join` to fire (invites cog)
- `message_content = True` — required for `on_message` to read message text (quote capture)

Without these, member-join events and all message content are silently dropped by Discord.

### `main.py` — cog loader crashes on `__pycache__`

`os.listdir('./cogs')` returns every filesystem entry, including `__pycache__`. Attempting `bot.load_extension('cogs.__pycache__.__pycache__')` raises an `ImportError` at startup. Fixed by skipping entries that are not directories or whose names start with `_`.

## Test plan

- [ ] Bot starts without errors when `__pycache__` exists inside `cogs/`
- [ ] `on_member_join` fires correctly (requires `members` intent enabled in Discord Developer Portal)
- [ ] Quote capture works — message content is readable in the capture channel

https://claude.ai/code/session_01UbxBfrLjhiYgdeCDzx7a2q

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbxBfrLjhiYgdeCDzx7a2q)_