### PR TITLE
fix: null crashes in invites cog and empty-list crash in greetings view

### DIFF
--- a/cogs/invites/greetings_view.py
+++ b/cogs/invites/greetings_view.py
@@ -55,8 +55,15 @@ class PaginatorView(discord.ui.View):
     @discord.ui.button(label="Delete", style=ButtonStyle.red)
     async def delete_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         await self.delete_current_greeting(interaction)
-        if self.current_page == len(self.pages):
-            self.current_page -= 1
+        if not self.pages:
+            self.stop()
+            for child in self.children:
+                if isinstance(child, discord.ui.Button):
+                    child.disabled = True
+            await interaction.response.edit_message(content="No greetings left.", embed=None, view=self)
+            return
+        if self.current_page >= len(self.pages):
+            self.current_page = len(self.pages) - 1
         await self.update_message(interaction)
 
     @discord.ui.button(label="Next", style=ButtonStyle.gray)

--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -99,8 +99,9 @@ class Invites(commands.Cog):
         for invite in recorded_invites:
             if invite['code'] not in [i.code for i in server_invites]:
                 inviter = member.guild.get_member(invite['author_id'])
-                print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter.name}")
-                inviter_id = inviter.id
+                inviter_id = inviter.id if inviter is not None else invite['author_id']
+                inviter_name = inviter.name if inviter is not None else f"(left) {invite['author_id']}"
+                print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter_name}")
                 await collection.delete_one({"code": invite['code']})
                 break
 
@@ -113,8 +114,8 @@ class Invites(commands.Cog):
             if announcement_channel is not None:
                 embed = discord.Embed(
                     title="Bienvenue!",
-                    thumbnail= member.avatar.url,
-                    color=member.accent_color,
+                    thumbnail=member.display_avatar.url,
+                    color=member.accent_color or discord.Color.default(),
                     description=f"Bienvenue a <@{member.id}>, {f"invité.e par <@{inviter_id}>" if inviter_id is not None else ""} sur le discord de [Phoenix Legacy](https://phxlgc.com)!"
                 )
                 await announcement_channel.send(embed=embed)


### PR DESCRIPTION
## Summary

Four crashes across `invites.py` and `greetings_view.py`.

### `cogs/invites/invites.py` — three `AttributeError` crashes in `on_member_join`

**1. Inviter has left the server**
`guild.get_member()` returns `None` when the inviting user is no longer in the guild. The next lines unconditionally accessed `.name` and `.id` on that `None`, aborting the entire join handler (role assignment + welcome message never ran). Now falls back to the stored `author_id` for the announcement mention.

**2. Member with no custom avatar**
`member.avatar` is `None` for users who have never set a custom avatar; calling `.url` on it crashes. Changed to `member.display_avatar.url`, which always resolves (falls back to the default Discord avatar URL).

**3. `member.accent_color` is `None` when unset**
`accent_color` is `None` by default and only populated once the member's profile is fully loaded. Passing `None` to `discord.Embed(color=...)` is silently wrong. Added `or discord.Color.default()` fallback.

### `cogs/invites/greetings_view.py` — `IndexError` after deleting the last greeting

After `self.pages.remove(greeting)`, if the list is now empty the old code called `get_embed()` which does `self.pages[self.current_page]` on an empty list → `IndexError`. The existing guard also used `==` instead of `>=`, so it missed cases where `current_page` was already past the new end after an earlier deletion. Fixed by detecting the empty state first: stops the view, disables all buttons, and shows "No greetings left."

## Test plan

- [ ] Trigger `on_member_join` with an invite whose author has since left — confirm no crash, announcement still sends (with ID mention fallback)
- [ ] Trigger `on_member_join` for a user with no custom avatar — confirm welcome embed sends
- [ ] Trigger `on_member_join` for a user whose `accent_color` is `None` — confirm no crash
- [ ] Open the greetings paginator and delete the only remaining greeting — confirm "No greetings left." message with all buttons disabled, no crash

https://claude.ai/code/session_01UbxBfrLjhiYgdeCDzx7a2q

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbxBfrLjhiYgdeCDzx7a2q)_