### PR TITLE
fix: multiple bugs in topic cog

### DIFF
--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -84,10 +84,16 @@ class Topic(commands.Cog):
 
         collection: AsyncCollection[TopicEntry] = await self.bot.mongo.get_collection(ctx.guild_id, "topics")
         topic = await collection.find_one(filter={"roleId": str(role.id)})
+        if topic is None:
+            await ctx.respond("Topic not found in the database.")
+            return
         type_descriptor = topic_types[topic_type]
         color = discord.Color(int(type_descriptor["color"], 16))
 
         channel = self.bot.get_channel(int(topic["channelId"]))
+        if channel is None:
+            await ctx.respond("Topic channel no longer exists.")
+            return
         message = await channel.fetch_message(int(topic["messageId"]))
         prev_embed = message.embeds[0]
 
@@ -130,28 +136,43 @@ class Topic(commands.Cog):
             await ctx.respond("Topic not found in the database, you might need to delete this one manually")
             return
 
-        message = await ctx.fetch_message(int(topic["messageId"]))
+        channel = self.bot.get_channel(int(topic["channelId"]))
+        if channel is None:
+            await ctx.respond("Topic channel no longer exists.")
+            return
+        message = await channel.fetch_message(int(topic["messageId"]))
         await message.delete()
         await role.delete()
+        await collection.delete_one({"_id": topic["_id"]})
         await ctx.respond("Removed topic successfully!")
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        if str(payload.emoji) != "✅" or payload.member.bot:
+            return
         collection: AsyncCollection[TopicEntry] = await self.bot.mongo.get_collection(payload.guild_id, "topics")
         topic = await collection.find_one(filter={"messageId": str(payload.message_id)})
         if topic:
             guild = self.bot.get_guild(payload.guild_id)
             role = guild.get_role(int(topic["roleId"]))
+            if role is None:
+                print(f"[Topic] Role {topic['roleId']} not found, skipping add_roles.")
+                return
             await payload.member.add_roles(role)
             print(f"Added role {role.name} to user {payload.member.name}")
 
     @commands.Cog.listener()
     async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
+        if str(payload.emoji) != "✅":
+            return
         collection: AsyncCollection[TopicEntry] = await self.bot.mongo.get_collection(payload.guild_id, "topics")
         topic = await collection.find_one(filter={"messageId": str(payload.message_id)})
         if topic:
             guild = self.bot.get_guild(payload.guild_id)
             role = guild.get_role(int(topic["roleId"]))
+            if role is None:
+                print(f"[Topic] Role {topic['roleId']} not found, skipping remove_roles.")
+                return
             member = await guild.fetch_member(payload.user_id)
             await member.remove_roles(role)
             print(f"Removed role {role.name} from user {member.name}")


### PR DESCRIPTION
## Summary

Seven bugs in `cogs/topic/topic.py`, all causing crashes or silent wrong behaviour.

### `delete_topic` — three bugs

| Bug | Effect | Fix |
|-----|--------|-----|
| `ctx.fetch_message(id)` fetches from the *command's* channel, not the topic's channel | `discord.NotFound` whenever the command is run from a different channel | Fetch via `bot.get_channel(topic["channelId"])`, matching what `edit_topic` already does |
| MongoDB document never deleted | Stale reactions keep hitting the dead role indefinitely after deletion | Call `collection.delete_one` after deleting the message and role |
| No `None` guard on `get_channel` | `AttributeError` if the topic channel was deleted | Return early with a user-facing error |

### `edit_topic` — two bugs

| Bug | Effect | Fix |
|-----|--------|-----|
| `find_one` result not checked for `None` | `TypeError` when the role has no DB entry | Early return with error message |
| `bot.get_channel()` result not checked for `None` | `AttributeError` calling `.fetch_message()` on `None` | Return early with a user-facing error |

### `on_raw_reaction_add` / `on_raw_reaction_remove` — three bugs

| Bug | Effect | Fix |
|-----|--------|-----|
| No emoji filter | *Any* reaction to a topic message assigns/unassigns the role | Guard: `str(payload.emoji) != "✅"` |
| Bot's own ✅ (added after topic creation) triggers `on_raw_reaction_add` | Bot attempts to assign the role to itself | Guard: `payload.member.bot` |
| `guild.get_role()` returns `None` for manually-deleted roles | `TypeError` in `add_roles(None)` / `remove_roles(None)` | Return early with a log warning |

## Test plan

- [ ] `/topic delete` run from a different channel than where the topic embed was posted — confirm it deletes the correct message and removes the DB record
- [ ] `/topic edit` on a role not in the DB — confirm graceful error message
- [ ] `/topic edit` / `/topic delete` when the original channel was deleted — confirm graceful error message
- [ ] React with a non-✅ emoji on a topic message — confirm no role change
- [ ] Create a topic and let the bot add ✅ — confirm the bot is not assigned the role
- [ ] Manually delete a topic's role, then react ✅ — confirm warning log, no crash

https://claude.ai/code/session_01UbxBfrLjhiYgdeCDzx7a2q

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbxBfrLjhiYgdeCDzx7a2q)_