### PR TITLE
fix: delete greeting by _id and cast invite config IDs to int

### DIFF
--- a/cogs/invites/greetings_view.py
+++ b/cogs/invites/greetings_view.py
@@ -35,7 +35,7 @@ class PaginatorView(discord.ui.View):
     async def delete_current_greeting(self, interaction: discord.Interaction):
         greeting = self.pages[self.current_page]
         collection: AsyncCollection[Greeting] = await self.invites_cog.bot.mongo.get_collection(interaction.guild_id, "greetings")
-        await collection.delete_one({"greeting": greeting['greeting']})
+        await collection.delete_one({"_id": greeting['_id']})
         self.pages.remove(greeting)
 
     def update_buttons(self):

--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -82,7 +82,7 @@ class Invites(commands.Cog):
         # Add default role
         new_role_id = self.config.get('inviteRole', member.guild.id)
         if new_role_id is not None:
-            role_to_add = member.guild.get_role(new_role_id)
+            role_to_add = member.guild.get_role(int(new_role_id))
             if role_to_add is None:
                 print("no role found, ignoring for new member.")
             else:
@@ -109,7 +109,7 @@ class Invites(commands.Cog):
 
         announcement_channel_id = self.config.get('invitesChannel', member.guild.id)
         if announcement_channel_id:
-            announcement_channel = member.guild.get_channel(announcement_channel_id)
+            announcement_channel = member.guild.get_channel(int(announcement_channel_id))
             if announcement_channel is not None:
                 embed = discord.Embed(
                     title="Bienvenue!",


### PR DESCRIPTION
## Summary

Two bugs in the invites cog, both silent correctness failures.

### `cogs/invites/greetings_view.py` — delete by `_id`, not text content (fixes #17)

`delete_current_greeting` was calling `delete_one({"greeting": greeting['greeting']})`. MongoDB's `delete_one` removes the first matching document by natural order — not necessarily the one being displayed. If two greetings share identical text, the wrong document is silently deleted. Fixed by using the document's `_id`, which is unique and already present in the fetched object.

### `cogs/invites/invites.py` — cast config IDs to `int` (fixes #18)

`inviteRole` and `invitesChannel` are set manually in `config/invites.json` (there are no slash commands for them). A user who writes `"inviteRole": "123456789"` (string) instead of `"inviteRole": 123456789` (integer) would get `None` back from `get_role()` / `get_channel()`, since both methods require an integer key. The failure is completely silent — no error, no log — so role assignment and join announcements are simply skipped. Added `int()` coercion at the point of use, which handles both string and integer JSON values safely.

## Test plan

- [ ] Create two greetings with identical text, open the paginator, navigate to the second, delete — confirm the second document is removed (not the first)
- [ ] Set `inviteRole` as a string ID in `config/invites.json`, trigger a member join — confirm the role is correctly assigned
- [ ] Set `invitesChannel` as a string ID in `config/invites.json`, trigger a member join — confirm the announcement embed is sent

https://claude.ai/code/session_017YTW1phvoatdmiYNfjJZNV

---
_Generated by [Claude Code](https://claude.ai/code/session_017YTW1phvoatdmiYNfjJZNV)_