### PR TITLE
fix: guard None inviter and None avatar in on_member_join

### DIFF
--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -95,12 +95,16 @@ class Invites(commands.Cog):
 
         print(f"{len(server_invites)} invites server-side, {len(recorded_invites)} invites bot-side.")
 
+        server_invite_codes = {i.code for i in server_invites}
         inviter_id = None
         for invite in recorded_invites:
-            if invite['code'] not in [i.code for i in server_invites]:
+            if invite['code'] not in server_invite_codes:
                 inviter = member.guild.get_member(invite['author_id'])
-                print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter.name}")
-                inviter_id = inviter.id
+                if inviter:
+                    print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter.name}")
+                    inviter_id = inviter.id
+                else:
+                    print(f"{member.name} joined \"{member.guild.name}\" using invite {invite['code']} (inviter no longer in server)")
                 await collection.delete_one({"code": invite['code']})
                 break
 
@@ -113,9 +117,9 @@ class Invites(commands.Cog):
             if announcement_channel is not None:
                 embed = discord.Embed(
                     title="Bienvenue!",
-                    thumbnail= member.avatar.url,
+                    thumbnail=member.display_avatar.url,
                     color=member.accent_color,
-                    description=f"Bienvenue a <@{member.id}>, {f"invité.e par <@{inviter_id}>" if inviter_id is not None else ""} sur le discord de [Phoenix Legacy](https://phxlgc.com)!"
+                    description=f"Bienvenue a <@{member.id}>, {f'invité.e par <@{inviter_id}>' if inviter_id is not None else ''} sur le discord de [Phoenix Legacy](https://phxlgc.com)!"
                 )
                 await announcement_channel.send(embed=embed)
 


### PR DESCRIPTION
Fixes #20

## Changes

### `cogs/invites/invites.py`

**Crash 1 — inviter left the guild**

`get_member()` returns `None` when the invite author is no longer in the server. The original code accessed `.name` and `.id` unconditionally, crashing the entire `on_member_join` handler (no role assignment, no announcement for the new member).

Now guarded with an `if inviter:` check — the invite is still cleaned up from the database, but `inviter_id` stays `None` so the announcement renders without an inviter mention.

**Crash 2 — member has no custom avatar**

`member.avatar` is `None` for accounts using Discord's default avatar. Accessing `.url` on it raised `AttributeError` before the embed was even built.

Changed to `member.display_avatar.url`, which always resolves to a valid URL (falling back to the generated default avatar).

**Bonus: O(n²) → O(n) invite lookup**

Also converted the repeated `[i.code for i in server_invites]` list comprehension inside the loop to a set built once before the loop, making the lookup O(1) per recorded invite instead of O(n).

## Test plan
- [ ] Member joins using a valid invite from a user still in the server — role assigned, announcement sent with inviter mention
- [ ] Member joins using an invite from a user who has since left — role assigned, announcement sent without inviter mention, no crash
- [ ] Member with no custom avatar joins — announcement embed renders correctly using the default avatar URL, no crash

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqSrxJsv4FARCZjXs29Kox)_