### PR TITLE
fix: add HTTP timeout to generate_quote_image and handle errors at call sites

### DIFF
--- a/cogs/quotes/quote_image.py
+++ b/cogs/quotes/quote_image.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 
 import aiohttp
@@ -6,6 +7,7 @@ from PIL import Image, ImageDraw, ImageFont, ImageFilter
 IMG_W = 800
 IMG_H = 800
 PADDING = 120
+_HTTP_TIMEOUT = aiohttp.ClientTimeout(total=10)
 
 
 def _wrap_text(draw: ImageDraw.ImageDraw, text: str, font, max_width: int) -> list[str]:
@@ -39,7 +41,7 @@ def _render(bg_data: bytes, quote: str, author: str, font_path: str) -> bytes:
     font_deco = ImageFont.truetype(font_path, 220)
 
     # Decorative opening quote mark (faint, top-left)
-    draw.text((50, -40), '\u201c', font=font_deco, fill=(255, 255, 255, 45))
+    draw.text((50, -40), '“', font=font_deco, fill=(255, 255, 255, 45))
 
     # Wrap and vertically center quote text
     lines = _wrap_text(draw, quote, font_quote, IMG_W - PADDING * 2)
@@ -54,7 +56,7 @@ def _render(bg_data: bytes, quote: str, author: str, font_path: str) -> bytes:
         y += line_h
 
     # Author centered near bottom
-    author_str = f'\u2014 {author}'
+    author_str = f'— {author}'
     ax = int((IMG_W - draw.textlength(author_str, font=font_author)) // 2)
     ay = IMG_H - 90
     draw.text((ax + 2, ay + 2), author_str, font=font_author, fill=(0, 0, 0, 180))
@@ -66,7 +68,7 @@ def _render(bg_data: bytes, quote: str, author: str, font_path: str) -> bytes:
 
 
 async def generate_quote_image(quote: str, author: str, font_path: str) -> bytes:
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(timeout=_HTTP_TIMEOUT) as session:
         async with session.get(f'https://picsum.photos/{IMG_W}/{IMG_H}', allow_redirects=True) as resp:
             bg_data = await resp.read()
     return _render(bg_data, quote, author, font_path)

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -1,9 +1,11 @@
+import asyncio
 import io
 import random
 import re
 from datetime import datetime
 from typing import TypedDict
 
+import aiohttp
 import discord
 from discord.ext import commands
 from pymongo.asynchronous.collection import AsyncCollection
@@ -37,7 +39,12 @@ class QuoteView(discord.ui.View):
         self.current_idx, quote = random.choice(safe_quotes)
         total = len(all_quotes)
 
-        image_bytes = await generate_quote_image(quote['quote'], quote.get('author', ''), self.quotes_cog.config.get('fontPath'))
+        try:
+            image_bytes = await generate_quote_image(quote['quote'], quote.get('author', ''), self.quotes_cog.config.get('fontPath'))
+        except (aiohttp.ClientError, asyncio.TimeoutError):
+            await interaction.response.send_message('Could not fetch background image. Please try again later.', ephemeral=True)
+            return
+
         file = discord.File(io.BytesIO(image_bytes), filename='quote.jpg')
         content = self.quotes_cog._quote_content(quote, self.current_idx + 1, total, notify=self.notify)
 
@@ -111,7 +118,12 @@ class Quotes(commands.Cog):
                 return
             idx, quote = random.choice(safe_quotes)
 
-        image_bytes = await generate_quote_image(quote['quote'], quote.get('author', ''), self.config.get('fontPath'))
+        try:
+            image_bytes = await generate_quote_image(quote['quote'], quote.get('author', ''), self.config.get('fontPath'))
+        except (aiohttp.ClientError, asyncio.TimeoutError):
+            await ctx.respond('Could not fetch background image. Please try again later.')
+            return
+
         file = discord.File(io.BytesIO(image_bytes), filename='quote.jpg')
         notify = ctx.author.mention if use_reply_channel else None
         view = QuoteView(self, ctx.guild_id, idx, notify)


### PR DESCRIPTION
Fixes #22

## Changes

### `cogs/quotes/quote_image.py`

Added a module-level `aiohttp.ClientTimeout(total=10)` and passed it to the `ClientSession`. Without this, a slow or unreachable `picsum.photos` request would await forever, blocking the entire Discord event loop for all subsequent events.

### `cogs/quotes/quotes.py`

Wrapped both `generate_quote_image` call sites (`/quote` command and the Reroll button) in `try/except (aiohttp.ClientError, asyncio.TimeoutError)` blocks. On failure the user now receives a clear error message instead of the command silently dying with an unhandled exception.

## Test plan
- [ ] `/quote` succeeds normally when picsum.photos is reachable
- [ ] `/quote` responds with a friendly error message when the network request times out (can be tested by temporarily pointing to an unreachable host)
- [ ] Reroll button behaves the same way (success / graceful failure)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqSrxJsv4FARCZjXs29Kox)_