### PR TITLE
fix: delete_topic fetches from correct channel; guard None role in reaction handlers

### DIFF
--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -50,7 +50,7 @@ class Topic(commands.Cog):
 
         # send a new embed message for users to react to
         embed = discord.Embed(
-            title=f"{name} {type_descriptor["emoji"]} {type_descriptor["text"]}",
+            title=f"{name} {type_descriptor['emoji']} {type_descriptor['text']}",
             color=color,
             footer=discord.embeds.EmbedFooter(text="Clique sur ✅ pour t'abonner à ce topic"),
             # TODO: maybe cache the picture before, so if the original link dies, we still have a reliable url
@@ -101,7 +101,7 @@ class Topic(commands.Cog):
 
         # create a new embed message to update
         embed = discord.Embed(
-            title=f"{name} {type_descriptor["emoji"]} {type_descriptor["text"]}",
+            title=f"{name} {type_descriptor['emoji']} {type_descriptor['text']}",
             color=color,
             footer=discord.embeds.EmbedFooter(text="Clique sur ✅ pour t'abonner à ce topic"),
             # TODO: maybe cache the picture before, so if the original link dies, we still have a reliable url
@@ -130,8 +130,15 @@ class Topic(commands.Cog):
             await ctx.respond("Topic not found in the database, you might need to delete this one manually")
             return
 
-        message = await ctx.fetch_message(int(topic["messageId"]))
-        await message.delete()
+        channel = self.bot.get_channel(int(topic["channelId"]))
+        if channel is not None:
+            try:
+                message = await channel.fetch_message(int(topic["messageId"]))
+                await message.delete()
+            except discord.NotFound:
+                pass
+
+        await collection.delete_one({"_id": topic["_id"]})
         await role.delete()
         await ctx.respond("Removed topic successfully!")
 
@@ -142,6 +149,8 @@ class Topic(commands.Cog):
         if topic:
             guild = self.bot.get_guild(payload.guild_id)
             role = guild.get_role(int(topic["roleId"]))
+            if role is None:
+                return
             await payload.member.add_roles(role)
             print(f"Added role {role.name} to user {payload.member.name}")
 
@@ -152,6 +161,8 @@ class Topic(commands.Cog):
         if topic:
             guild = self.bot.get_guild(payload.guild_id)
             role = guild.get_role(int(topic["roleId"]))
+            if role is None:
+                return
             member = await guild.fetch_member(payload.user_id)
             await member.remove_roles(role)
             print(f"Removed role {role.name} from user {member.name}")


### PR DESCRIPTION
Fixes #24

## Changes

### `cogs/topic/topic.py`

**`delete_topic` — wrong channel for message fetch**

`ctx.fetch_message()` only looks up messages in the current interaction channel. Topic embeds are created in whichever channel `/topic create` was run in, so running `/topic delete` from any other channel raised `discord.NotFound` silently.

Now the command looks up the channel from `topic["channelId"]` (already stored in the DB) and fetches the message from there. A missing channel or already-deleted message is handled gracefully with `try/except discord.NotFound` so the database entry and role are still cleaned up even if the embed is gone.

**Reaction handlers — `get_role()` returning `None` on deleted roles**

`guild.get_role()` returns `None` when the role has been deleted. Passing `None` to `add_roles()` / `remove_roles()` raised `TypeError` on every reaction to a topic whose role no longer exists, filling logs with unhandled exceptions.

Added an early-return guard (`if role is None: return`) in both `on_raw_reaction_add` and `on_raw_reaction_remove`.

## Test plan
- [ ] `/topic delete` run from a different channel than where the topic was created — message is deleted and role is removed correctly
- [ ] `/topic delete` when the topic message was already manually deleted — command still removes the DB entry and role without error
- [ ] Adding ✅ reaction to a topic whose role has been deleted — no unhandled exception, handler exits silently
- [ ] Normal topic subscription/unsubscription still works

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqSrxJsv4FARCZjXs29Kox)_