### PR TITLE
fix: guard on_raw_reaction_remove against user having left the guild

### DIFF
--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -151,8 +151,15 @@ class Topic(commands.Cog):
         topic = await collection.find_one(filter={"messageId": str(payload.message_id)})
         if topic:
             guild = self.bot.get_guild(payload.guild_id)
+            if guild is None:
+                return
             role = guild.get_role(int(topic["roleId"]))
-            member = await guild.fetch_member(payload.user_id)
+            if role is None:
+                return
+            try:
+                member = await guild.fetch_member(payload.user_id)
+            except discord.NotFound:
+                return
             await member.remove_roles(role)
             print(f"Removed role {role.name} from user {member.name}")
 


### PR DESCRIPTION
Fixes #26

## Changes

### `cogs/topic/topic.py` — `on_raw_reaction_remove`

Unlike `on_raw_reaction_add` (which receives `payload.member` directly), `on_raw_reaction_remove` must call `guild.fetch_member()` to get the member object. If the user has left the guild — which is exactly when Discord fires bulk reaction-remove events — the API returns a 404 and py-cord raises `discord.NotFound`. This was unhandled, crashing the listener and filling logs with tracebacks on every such event.

**Changes:**
- Wrap `guild.fetch_member()` in `try/except discord.NotFound` and return early when the member is gone
- Add a `None` guard for `get_guild()` (edge case: event fires after bot leaves the guild)
- Add a `None` guard for `get_role()` (role was manually deleted while topic still in DB) — consistent with the guard already being added to `on_raw_reaction_add` in PR #25

## Test plan
- [ ] User reacts ✅ to a topic message (role assigned), then leaves the guild — no unhandled exception in logs
- [ ] User reacts ✅ and then removes the reaction normally — role is removed correctly
- [ ] `/topic delete` to remove the topic's role manually, then a user removes their ✅ reaction — handler exits silently, no crash

https://claude.ai/code/session_01VwrNBWHqFXQmXsa4647RNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwrNBWHqFXQmXsa4647RNM)_