### PR TITLE
fix: handle None expires_at for permanent invites (inviteMaxAge=0)

### DIFF
--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -62,7 +62,7 @@ class Invites(commands.Cog):
         invite_entry = InviteEntry(
             author_id=author.id,
             code=invite.code,
-            expires=int(invite.expires_at.timestamp())
+            expires=int(invite.expires_at.timestamp()) if invite.expires_at else None
         )
         collection: AsyncCollection[InviteEntry] = await self.bot.mongo.get_collection(ctx.guild_id, "invites")
         await collection.insert_one(invite_entry)
@@ -129,7 +129,7 @@ class Invites(commands.Cog):
             invites_num = len(recorded_invites)
 
             for invite in recorded_invites:
-                if invite['expires'] - datetime.datetime.now().timestamp() < 0:
+                if invite['expires'] is not None and invite['expires'] - datetime.datetime.now().timestamp() < 0:
                     await collection.delete_one({"code": invite['code']})
                     invites_num -= 1
                     print(f"Deleted expired invite: {invite['code']}. {invites_num} remaining.")


### PR DESCRIPTION
Fixes #30

## Changes

### `cogs/invites/invites.py`

**`/invite` — `expires_at` is `None` for permanent invites**

When `inviteMaxAge` is `0`, Discord creates a never-expiring invite and sets `expires_at=None`. The original code called `.timestamp()` on it unconditionally, crashing with `AttributeError` before the invite link was ever returned to the user.

Now stores `None` in the database when the invite has no expiry.

**`on_ready` — expiry comparison crashes on stored `None` expires**

The startup cleanup loop subtracted the current timestamp from `invite['expires']`. If a permanent invite entry is in the database (`expires=None`), this produced `TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'`.

Added a `None` guard so permanent invites are simply skipped during cleanup (they never expire, so there is nothing to clean up).

## Test plan
- [ ] Set `"inviteMaxAge": 0` in `config/invites.json`, run `/invite` — confirm a valid permanent invite link is returned
- [ ] Restart the bot with a permanent invite in the DB — confirm startup completes without error and the entry is not deleted
- [ ] Non-zero `inviteMaxAge` still works as before

https://claude.ai/code/session_01CzUM1SqRz5KVcjFzn56XXN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzUM1SqRz5KVcjFzn56XXN)_