### PR TITLE
fix: guard /test_join against user not in the guild

### DIFF
--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -74,6 +74,9 @@ class Invites(commands.Cog):
     async def test_join(self, ctx: discord.ApplicationContext, user: discord.User):
         await ctx.defer(ephemeral=True)
         member = ctx.guild.get_member(user.id)
+        if member is None:
+            await ctx.respond(f"{user.mention} is not a member of this server.")
+            return
         await self.on_member_join(member)
         await ctx.respond("test_join succeeded!")
 


### PR DESCRIPTION
Fixes #31

## Changes

### `cogs/invites/invites.py` — `test_join`

`ctx.guild.get_member(user.id)` returns `None` when the supplied user is not currently a member of the server. Passing `None` to `on_member_join` caused an immediate `AttributeError` at `member.guild.id` — the handler crashed before doing anything, and the caller received no response (Discord shows "Application did not respond").

Added a `None` guard that returns a clear error message to the invoker instead of crashing.

## Test plan
- [ ] Run `/test_join` with a user who is in the server — confirms the join flow runs and responds "test_join succeeded!"
- [ ] Run `/test_join` with a user who is **not** in the server — confirms a friendly error message is returned, no crash

https://claude.ai/code/session_01CzUM1SqRz5KVcjFzn56XXN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzUM1SqRz5KVcjFzn56XXN)_