### PR TITLE
fix: always save config on init so files are created from defaults on first run

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -9,8 +9,7 @@ class Config:
         loaded = self.load()
         self._global: dict = default_config | loaded.get('global', {})
         self._guilds: dict[str, dict] = loaded.get('guilds', {})
-        if loaded:
-            self.save()
+        self.save()
 
     @property
     def config(self) -> dict:


### PR DESCRIPTION
Fixes #36

## Changes

### `src/config.py` — `__init__`

When `config/<cog>.json` does not exist, `load()` returns `{}` (empty dict). An empty dict is falsy, so the previous `if loaded: self.save()` guard never called `save()` on first run — the file was never written to disk.

In practice this meant:
- Config files were never auto-created; users had nothing to inspect or hand-edit on a fresh deploy
- Cogs that rely on hand-edited values (e.g. `inviteRole`, `invitesChannel`) silently ignored the settings because no file was ever created to edit

**Fix:** remove the conditional and call `save()` unconditionally. On first run this writes the defaults to disk; on subsequent runs it re-serialises the loaded+merged config (same behaviour as before for already-existing files).

## Test plan
- [ ] Delete all `config/*.json` files, start the bot — confirm each file is created with defaults on startup
- [ ] Config values set via slash commands persist across restarts as before

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReWtNwDeQ91z3GQV5s2gvo)_