### PR TITLE
fix: guard /greetings paginate against empty greetings collection

### DIFF
--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -44,6 +44,9 @@ class Invites(commands.Cog):
         await ctx.defer(ephemeral=True)
         collection: AsyncCollection[Greeting] = await self.bot.mongo.get_collection(ctx.guild_id, "greetings")
         greetings = await collection.find({}).to_list()
+        if not greetings:
+            await ctx.respond("No greetings have been created yet.")
+            return
         view = PaginatorView(self, greetings, id)
         await ctx.respond(
             content=view.get_content(),


### PR DESCRIPTION
Fixes #39

## Changes

### `cogs/invites/invites.py` — `paginate`

When the `greetings` collection is empty, `PaginatorView` was constructed with `pages=[]`. `get_embed()` then called `self.pages[0]` unconditionally, raising `IndexError` before the command could respond — Discord showed "Application did not respond".

PR #14 fixed the same crash for the case where the last greeting is deleted *during* a paginator session (the `delete_button` handler now detects an empty list and shows "No greetings left."). The initial invocation path was not covered.

Added a guard that responds with "No greetings have been created yet." and returns early when the fetched list is empty.

## Test plan

- [ ] Run `/greetings paginate` with no greetings in the database — confirm a friendly message is returned, no crash
- [ ] Run `/greetings paginate` with greetings present — confirm normal paginator behaviour is unchanged

https://claude.ai/code/session_011E9nVjkHMPT472jDBSLBA7

---
_Generated by [Claude Code](https://claude.ai/code/session_011E9nVjkHMPT472jDBSLBA7)_