### PR TITLE
fix: guard inviter, avatar, and accent_color in on_member_join

### DIFF
--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -105,8 +105,9 @@ class Invites(commands.Cog):
         for invite in recorded_invites:
             if invite['code'] not in [i.code for i in server_invites]:
                 inviter = member.guild.get_member(invite['author_id'])
-                print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter.name}")
-                inviter_id = inviter.id
+                inviter_name = inviter.name if inviter else f"<unknown {invite['author_id']}>"
+                print(f"{member.name} joined \"{member.guild.name}\" using the invite {invite['code']} by {inviter_name}")
+                inviter_id = inviter.id if inviter else invite['author_id']
                 await collection.delete_one({"code": invite['code']})
                 break
 
@@ -119,8 +120,8 @@ class Invites(commands.Cog):
             if announcement_channel is not None:
                 embed = discord.Embed(
                     title="Bienvenue!",
-                    thumbnail= member.avatar.url,
-                    color=member.accent_color,
+                    thumbnail=member.avatar.url if member.avatar else None,
+                    color=member.accent_color or discord.Color.default(),
                     description=f"Bienvenue a <@{member.id}>, {f"invité.e par <@{inviter_id}>" if inviter_id is not None else ""} sur le discord de [Phoenix Legacy](https://phxlgc.com)!"
                 )
                 await announcement_channel.send(embed=embed)


### PR DESCRIPTION
Fixes #41

## Changes

### `cogs/invites/invites.py` — `on_member_join`

**Inviter can be None** when the user who created the invite has since left the guild. `guild.get_member()` returns `None` in that case, so `inviter.name` and `inviter.id` both crash with `AttributeError`. Fixed by guarding both accesses:

```python
inviter_name = inviter.name if inviter else f"<unknown {invite['author_id']}>"
inviter_id = inviter.id if inviter else invite['author_id']
```

**`member.avatar` can be None** for members using Discord's default avatar. Fixed by guarding the `.url` access:

```python
thumbnail=member.avatar.url if member.avatar else None,
```

**`member.accent_color` is None** for the vast majority of members. Fixed with a safe fallback:

```python
color=member.accent_color or discord.Color.default(),
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyCyo11aNuU3Hsud3VpA4p)_