### PR TITLE
fix: cast inviteRole and invitesChannel config IDs to int

### DIFF
--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -88,7 +88,7 @@ class Invites(commands.Cog):
         # Add default role
         new_role_id = self.config.get('inviteRole', member.guild.id)
         if new_role_id is not None:
-            role_to_add = member.guild.get_role(new_role_id)
+            role_to_add = member.guild.get_role(int(new_role_id))
             if role_to_add is None:
                 print("no role found, ignoring for new member.")
             else:
@@ -115,7 +115,7 @@ class Invites(commands.Cog):
 
         announcement_channel_id = self.config.get('invitesChannel', member.guild.id)
         if announcement_channel_id:
-            announcement_channel = member.guild.get_channel(announcement_channel_id)
+            announcement_channel = member.guild.get_channel(int(announcement_channel_id))
             if announcement_channel is not None:
                 embed = discord.Embed(
                     title="Bienvenue!",


### PR DESCRIPTION
Fixes #43

## Changes

### `cogs/invites/invites.py` — `on_member_join`

`get_role()` and `get_channel()` both require an `int` ID. When `inviteRole` or `invitesChannel` is written as a JSON string (`"123456789"`) rather than an integer (`123456789`), these lookups return `None` silently — breaking role assignment and join announcements with no log or error.

```python
role_to_add = member.guild.get_role(int(new_role_id))
announcement_channel = member.guild.get_channel(int(announcement_channel_id))
```

`int()` is idempotent for both string and int inputs, so this handles either JSON representation without requiring users to change existing configs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyCyo11aNuU3Hsud3VpA4p)_