### PR TITLE
fix: delete greeting by _id instead of text content

### DIFF
--- a/cogs/invites/greetings_view.py
+++ b/cogs/invites/greetings_view.py
@@ -35,7 +35,7 @@ class PaginatorView(discord.ui.View):
     async def delete_current_greeting(self, interaction: discord.Interaction):
         greeting = self.pages[self.current_page]
         collection: AsyncCollection[Greeting] = await self.invites_cog.bot.mongo.get_collection(interaction.guild_id, "greetings")
-        await collection.delete_one({"greeting": greeting['greeting']})
+        await collection.delete_one({"_id": greeting['_id']})
         self.pages.remove(greeting)
 
     def update_buttons(self):


### PR DESCRIPTION
Fixes #44

## Changes

### `cogs/invites/greetings_view.py` — `delete_current_greeting`

`delete_one({"greeting": greeting['greeting']})` deletes the first document matching the greeting text, not necessarily the one currently displayed. When two greetings share identical text this silently removes the wrong entry.

```python
await collection.delete_one({"_id": greeting['_id']})
```

`_id` is unique per document and is already present in the fetched greeting dict, so this always deletes exactly the displayed entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyCyo11aNuU3Hsud3VpA4p)_