### PR TITLE
fix: guard fetch_member in on_raw_reaction_remove against NotFound

### DIFF
--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -163,7 +163,10 @@ class Topic(commands.Cog):
             role = guild.get_role(int(topic["roleId"]))
             if role is None:
                 return
-            member = await guild.fetch_member(payload.user_id)
+            try:
+                member = await guild.fetch_member(payload.user_id)
+            except discord.NotFound:
+                return
             await member.remove_roles(role)
             print(f"Removed role {role.name} from user {member.name}")
 


### PR DESCRIPTION
Fixes #45

## Changes

### `cogs/topic/topic.py` — `on_raw_reaction_remove`

A user can react to a topic message and later leave the guild. When Discord subsequently fires `on_raw_reaction_remove` for that user (e.g. the message is edited, or the reaction is cleared), `guild.fetch_member(payload.user_id)` raises `discord.NotFound` because the user is no longer in the guild. This kills the listener and logs an unhandled exception.

```python
try:
    member = await guild.fetch_member(payload.user_id)
except discord.NotFound:
    return
```

If the member is gone there is nothing to remove roles from, so returning early is the correct behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyCyo11aNuU3Hsud3VpA4p)_