### PR TITLE
fix: add HTTP timeout to generate_quote_image and handle errors at call sites

### DIFF
--- a/cogs/quotes/quote_image.py
+++ b/cogs/quotes/quote_image.py
@@ -66,7 +66,8 @@ def _render(bg_data: bytes, quote: str, author: str, font_path: str) -> bytes:
 
 
 async def generate_quote_image(quote: str, author: str, font_path: str) -> bytes:
-    async with aiohttp.ClientSession() as session:
+    timeout = aiohttp.ClientTimeout(total=10)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.get(f'https://picsum.photos/{IMG_W}/{IMG_H}', allow_redirects=True) as resp:
             bg_data = await resp.read()
     return _render(bg_data, quote, author, font_path)

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -1,9 +1,11 @@
+import asyncio
 import io
 import random
 import re
 from datetime import datetime
 from typing import TypedDict
 
+import aiohttp
 import discord
 from discord.ext import commands
 from pymongo.asynchronous.collection import AsyncCollection
@@ -37,7 +39,11 @@ class QuoteView(discord.ui.View):
         self.current_idx, quote = random.choice(safe_quotes)
         total = len(all_quotes)
 
-        image_bytes = await generate_quote_image(quote['quote'], quote.get('author', ''), self.quotes_cog.config.get('fontPath'))
+        try:
+            image_bytes = await generate_quote_image(quote['quote'], quote.get('author', ''), self.quotes_cog.config.get('fontPath'))
+        except (aiohttp.ClientError, asyncio.TimeoutError):
+            await interaction.response.send_message('Failed to fetch background image. Please try again.', ephemeral=True)
+            return
         file = discord.File(io.BytesIO(image_bytes), filename='quote.jpg')
         content = self.quotes_cog._quote_content(quote, self.current_idx + 1, total, notify=self.notify)
 
@@ -111,7 +117,11 @@ class Quotes(commands.Cog):
                 return
             idx, quote = random.choice(safe_quotes)
 
-        image_bytes = await generate_quote_image(quote['quote'], quote.get('author', ''), self.config.get('fontPath'))
+        try:
+            image_bytes = await generate_quote_image(quote['quote'], quote.get('author', ''), self.config.get('fontPath'))
+        except (aiohttp.ClientError, asyncio.TimeoutError):
+            await ctx.respond('Failed to fetch background image. Please try again.', ephemeral=True)
+            return
         file = discord.File(io.BytesIO(image_bytes), filename='quote.jpg')
         notify = ctx.author.mention if use_reply_channel else None
         view = QuoteView(self, ctx.guild_id, idx, notify)


### PR DESCRIPTION
Fixes #46

## Changes

### `cogs/quotes/quote_image.py` — `generate_quote_image`

Added a 10 s `ClientTimeout` to the aiohttp session. Without it, a slow or unreachable `picsum.photos` hangs the coroutine indefinitely, leaking the connection.

```python
timeout = aiohttp.ClientTimeout(total=10)
async with aiohttp.ClientSession(timeout=timeout) as session:
```

### `cogs/quotes/quotes.py` — `/quote` command and `QuoteView.reroll`

Both call sites now catch `aiohttp.ClientError` and `asyncio.TimeoutError` and respond with a user-friendly error message instead of silently failing (which would leave Discord showing "Application did not respond").

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyCyo11aNuU3Hsud3VpA4p)_