### PR TITLE
Cache topic images to prevent broken embeds

### DIFF
--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -1,5 +1,7 @@
-from typing import TypedDict
+import io
+from typing import Optional, TypedDict
 
+import aiohttp
 import discord
 from discord import option
 from discord.ext import commands
@@ -13,6 +15,7 @@ class TopicEntry(TypedDict):
     channelId: str
     roleId: str
     roleName: str
+    imageData: Optional[bytes]
 
 class Topic(commands.Cog):
     def __init__(self, bot: FriendlyFire):
@@ -29,6 +32,13 @@ class Topic(commands.Cog):
 
     async def get_topic_types(self, ctx: discord.AutocompleteContext):
         return list(self.config.get('topicTypes').keys())
+
+    async def _fetch_image(self, url: str) -> Optional[bytes]:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as resp:
+                if resp.status == 200:
+                    return await resp.read()
+        return None
 
     @topicGroup.command(name="create", description="create a topic", default_permission=False)
     @option(name="name", description="name of the new topic", required=True)
@@ -48,16 +58,21 @@ class Topic(commands.Cog):
         color = discord.Color(int(type_descriptor["color"], 16))
         role = await ctx.guild.create_role(name=name, color=color, mentionable=True)
 
-        # send a new embed message for users to react to
+        image_data = await self._fetch_image(image) if image else None
+
         embed = discord.Embed(
             title=f"{name} {type_descriptor['emoji']} {type_descriptor['text']}",
             color=color,
             footer=discord.embeds.EmbedFooter(text="Clique sur ✅ pour t'abonner à ce topic"),
-            # TODO: maybe cache the picture before, so if the original link dies, we still have a reliable url
-            image=image
         )
 
-        message = await ctx.channel.send(embed=embed)
+        if image_data:
+            embed.set_image(url="attachment://topic.png")
+            file = discord.File(io.BytesIO(image_data), filename="topic.png")
+            message = await ctx.channel.send(file=file, embed=embed)
+        else:
+            message = await ctx.channel.send(embed=embed)
+
         await message.add_reaction("✅")
 
         collection: AsyncCollection[TopicEntry] = await self.bot.mongo.get_collection(ctx.guild_id, "topics")
@@ -65,7 +80,8 @@ class Topic(commands.Cog):
             messageId=str(message.id),
             channelId=str(message.channel.id),
             roleId=str(role.id),
-            roleName=role.name
+            roleName=role.name,
+            imageData=image_data
         ))
         await ctx.respond("Created topic successfully!")
 
@@ -89,32 +105,38 @@ class Topic(commands.Cog):
 
         channel = self.bot.get_channel(int(topic["channelId"]))
         message = await channel.fetch_message(int(topic["messageId"]))
-        prev_embed = message.embeds[0]
 
         if name is None:
             name = topic["roleName"]
         else:
             await role.edit(name=name)
 
-        if image is None:
-            image = prev_embed.image
+        # Use newly downloaded image, fall back to previously cached bytes
+        image_data = topic.get("imageData")
+        if image is not None:
+            image_data = await self._fetch_image(image) or image_data
 
-        # create a new embed message to update
         embed = discord.Embed(
             title=f"{name} {type_descriptor['emoji']} {type_descriptor['text']}",
             color=color,
             footer=discord.embeds.EmbedFooter(text="Clique sur ✅ pour t'abonner à ce topic"),
-            # TODO: maybe cache the picture before, so if the original link dies, we still have a reliable url
-            image=image
         )
 
         await role.edit(color=color)
-        await message.edit(embed=embed)
+
+        if image_data:
+            embed.set_image(url="attachment://topic.png")
+            file = discord.File(io.BytesIO(image_data), filename="topic.png")
+            await message.edit(attachments=[], file=file, embed=embed)
+        else:
+            await message.edit(embed=embed)
+
         await collection.update_one(filter={"_id": topic["_id"]}, update={"$set": {
             "messageId": str(message.id),
             "channelId": str(message.channel.id),
             "roleId": str(role.id),
-            "roleName": str(role.name)
+            "roleName": str(role.name),
+            "imageData": image_data
         }})
 
         await ctx.respond("Updated topic successfully!")

--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -1,5 +1,5 @@
 import io
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 import aiohttp
 import discord
@@ -15,7 +15,6 @@ class TopicEntry(TypedDict):
     channelId: str
     roleId: str
     roleName: str
-    imageData: Optional[bytes]
 
 class Topic(commands.Cog):
     def __init__(self, bot: FriendlyFire):
@@ -33,7 +32,7 @@ class Topic(commands.Cog):
     async def get_topic_types(self, ctx: discord.AutocompleteContext):
         return list(self.config.get('topicTypes').keys())
 
-    async def _fetch_image(self, url: str) -> Optional[bytes]:
+    async def _fetch_image(self, url: str) -> bytes | None:
         async with aiohttp.ClientSession() as session:
             async with session.get(url) as resp:
                 if resp.status == 200:
@@ -58,18 +57,16 @@ class Topic(commands.Cog):
         color = discord.Color(int(type_descriptor["color"], 16))
         role = await ctx.guild.create_role(name=name, color=color, mentionable=True)
 
-        image_data = await self._fetch_image(image) if image else None
-
         embed = discord.Embed(
             title=f"{name} {type_descriptor['emoji']} {type_descriptor['text']}",
             color=color,
             footer=discord.embeds.EmbedFooter(text="Clique sur ✅ pour t'abonner à ce topic"),
         )
 
+        image_data = await self._fetch_image(image) if image else None
         if image_data:
             embed.set_image(url="attachment://topic.png")
-            file = discord.File(io.BytesIO(image_data), filename="topic.png")
-            message = await ctx.channel.send(file=file, embed=embed)
+            message = await ctx.channel.send(file=discord.File(io.BytesIO(image_data), filename="topic.png"), embed=embed)
         else:
             message = await ctx.channel.send(embed=embed)
 
@@ -80,8 +77,7 @@ class Topic(commands.Cog):
             messageId=str(message.id),
             channelId=str(message.channel.id),
             roleId=str(role.id),
-            roleName=role.name,
-            imageData=image_data
+            roleName=role.name
         ))
         await ctx.respond("Created topic successfully!")
 
@@ -111,11 +107,6 @@ class Topic(commands.Cog):
         else:
             await role.edit(name=name)
 
-        # Use newly downloaded image, fall back to previously cached bytes
-        image_data = topic.get("imageData")
-        if image is not None:
-            image_data = await self._fetch_image(image) or image_data
-
         embed = discord.Embed(
             title=f"{name} {type_descriptor['emoji']} {type_descriptor['text']}",
             color=color,
@@ -124,10 +115,17 @@ class Topic(commands.Cog):
 
         await role.edit(color=color)
 
-        if image_data:
-            embed.set_image(url="attachment://topic.png")
-            file = discord.File(io.BytesIO(image_data), filename="topic.png")
-            await message.edit(attachments=[], file=file, embed=embed)
+        if image is not None:
+            image_data = await self._fetch_image(image)
+            if image_data:
+                embed.set_image(url="attachment://topic.png")
+                await message.edit(attachments=[], file=discord.File(io.BytesIO(image_data), filename="topic.png"), embed=embed)
+            else:
+                await message.edit(embed=embed)
+        elif message.attachments:
+            # retain the previously uploaded image
+            embed.set_image(url=message.attachments[0].url)
+            await message.edit(attachments=message.attachments, embed=embed)
         else:
             await message.edit(embed=embed)
 
@@ -135,8 +133,7 @@ class Topic(commands.Cog):
             "messageId": str(message.id),
             "channelId": str(message.channel.id),
             "roleId": str(role.id),
-            "roleName": str(role.name),
-            "imageData": image_data
+            "roleName": str(role.name)
         }})
 
         await ctx.respond("Updated topic successfully!")


### PR DESCRIPTION
Closes #53

## Summary

- Added `_fetch_image(url)` helper that downloads image bytes via `aiohttp`
- `create_topic`: downloads the image and uploads it to Discord as a file attachment; the embed references it via `attachment://topic.png` so it is invisible as a standalone download
- `edit_topic`: if a new image URL is given, re-downloads and re-uploads; otherwise retains the existing Discord attachment via `message.attachments`
- No extra data stored in MongoDB — `TopicEntry` schema is unchanged

## Test plan

- [ ] Create a topic with an image URL — confirm the embed displays the image with no visible attachment
- [ ] Edit a topic without changing the image — confirm the existing Discord-hosted image is preserved
- [ ] Edit a topic with a new image URL — confirm the embed updates to the new image
- [ ] Create a topic without an image — confirm the embed renders cleanly with no attachment