### PR TITLE
fix: prev button off-by-one and delete crash on last greeting in PaginatorView

### DIFF
--- a/cogs/invites/greetings_view.py
+++ b/cogs/invites/greetings_view.py
@@ -49,15 +49,19 @@ class PaginatorView(discord.ui.View):
 
     @discord.ui.button(label="Prev", style=ButtonStyle.gray)
     async def prev_button(self, button: discord.ui.Button, interaction: discord.Interaction):
-        if self.current_page - 1 > 0:
+        if self.current_page > 0:
             self.current_page -= 1
             await self.update_message(interaction)
 
     @discord.ui.button(label="Delete", style=ButtonStyle.red)
     async def delete_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         await self.delete_current_greeting(interaction)
-        if self.current_page == len(self.pages):
-            self.current_page -= 1
+        if not self.pages:
+            self.disable_all_items()
+            await interaction.response.edit_message(content="No greetings remaining.", embed=None, view=self)
+            return
+        if self.current_page >= len(self.pages):
+            self.current_page = len(self.pages) - 1
         await self.update_message(interaction)
 
     @discord.ui.button(label="Next", style=ButtonStyle.gray)


### PR DESCRIPTION
Fixes #56

## Summary

- **`prev_button`**: condition `self.current_page - 1 > 0` was off by one — navigating from page index 1 to index 0 (the first greeting) was impossible because `0 > 0` is `False`. Changed to `self.current_page > 0`.
- **`delete_button`**: deleting the last greeting left `self.pages` empty, then `current_page` was decremented to `-1`, and the subsequent `update_message` call raised `IndexError` via `self.pages[-1]`. Now handles the empty-list case explicitly (disables the view, responds with "No greetings remaining."); otherwise clamps `current_page` to a valid index with `>= len(self.pages)` instead of `==`.

## Test plan

- [ ] Open the greetings paginator on a guild with 3+ greetings — confirm Prev navigates all the way back to greeting #1
- [ ] Open the paginator with a single greeting, click Delete — confirm the view shows "No greetings remaining." without crashing
- [ ] Open the paginator with 2 greetings, navigate to the last, click Delete — confirm it shows greeting #1 correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBgXhN1VJT1TzZDMoQZSt7)_