### PR TITLE
fix: add HTTP timeout to _fetch_image and guard edit_topic against missing topic

### DIFF
--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 from typing import TypedDict
 
@@ -31,11 +32,12 @@ class Topic(BaseCog):
 
     async def _fetch_image(self, url: str) -> bytes | None:
         try:
-            async with aiohttp.ClientSession() as session:
+            timeout = aiohttp.ClientTimeout(total=10)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
                 async with session.get(url) as resp:
                     if resp.status == 200:
                         return await resp.read()
-        except aiohttp.ClientError:
+        except (aiohttp.ClientError, asyncio.TimeoutError):
             self.log(f'Failed to fetch image from {url}')
         return None
 
@@ -96,6 +98,9 @@ class Topic(BaseCog):
 
         collection: AsyncCollection[TopicEntry] = await self.bot.mongo.get_collection(ctx.guild_id, "topics")
         topic = await collection.find_one(filter={"roleId": str(role.id)})
+        if topic is None:
+            await ctx.respond("Topic not found in the database, you might need to delete this one manually.")
+            return
         type_descriptor = topic_types[topic_type]
         color = discord.Color(int(type_descriptor["color"], 16))
 


### PR DESCRIPTION
Fixes #57

## Summary

- **`_fetch_image` timeout**: added `aiohttp.ClientTimeout(total=10)` so that a slow or unreachable image URL does not hang the `/topic create` or `/topic edit` interaction indefinitely. Also catches `asyncio.TimeoutError` alongside `aiohttp.ClientError`, matching the pattern from PR #52 (`quote_image.py`).
- **`edit_topic` None guard**: `find_one` returns `None` when the role has no matching topic document (e.g. the DB was cleared or the role was never registered as a topic). Without a guard, `topic["channelId"]` immediately raises `TypeError`. Added the same early-return guard already present in `delete_topic`.

## Test plan

- [ ] Run `/topic edit` with a role that is not a registered topic — confirm it responds with "Topic not found in the database…" instead of crashing
- [ ] Run `/topic create` or `/topic edit` with an image URL hosted on a very slow server — confirm the command times out gracefully after ~10 s and does not hang the bot

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBgXhN1VJT1TzZDMoQZSt7)_