### PR TITLE
Refactor quotes view and add delete functionality

### DIFF
--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -10,7 +10,7 @@ import discord
 from discord.ext import commands
 from pymongo.asynchronous.collection import AsyncCollection
 
-from cogs.quotes.check_quotes_view import CheckQuotesView
+from cogs.quotes.quotes_paginate_view import QuotesPaginateView
 from cogs.quotes.quote_image import generate_quote_image
 from src import FriendlyFire, BaseCog
 
@@ -131,9 +131,9 @@ class Quotes(BaseCog):
         else:
             await ctx.respond(content=content, file=file, view=view)
 
-    @discord.slash_command(name="check-quotes", description="Open the quote moderation view.", default_permission=False)
+    @quotesGroup.command(name="paginate", description="Open the quote paginator/moderation view.", default_permission=False)
     @discord.option(name="id", parameter_name="quote_id", description="Id of the quote to start at", required=False, input_type=int)
-    async def check_quotes(self, ctx: discord.ApplicationContext, quote_id: int = None):
+    async def paginate_quotes(self, ctx: discord.ApplicationContext, quote_id: int = None):
         await ctx.defer(ephemeral=True)
 
         collection: AsyncCollection[QuoteEntry] = await self.bot.mongo.get_collection(ctx.guild_id, "quotes")
@@ -149,7 +149,7 @@ class Quotes(BaseCog):
         else:
             idx = next((i for i, q in enumerate(quotes) if not q.get('checked', False)), 0)
 
-        view = CheckQuotesView(self, quotes, idx)
+        view = QuotesPaginateView(self, quotes, idx)
         await ctx.respond(embed=view.get_embed(), view=view)
 
     @discord.slash_command(name="crawl-missing-quotes", description="Crawl the quote channel to backfill missing quotes.", default_permission=False)

--- a/cogs/quotes/quotes_paginate_view.py
+++ b/cogs/quotes/quotes_paginate_view.py
@@ -6,7 +6,7 @@ from discord import ButtonStyle
 from pymongo.asynchronous.collection import AsyncCollection
 
 
-class CheckQuotesView(discord.ui.View):
+class QuotesPaginateView(discord.ui.View):
     def __init__(self, quotes_cog, quotes: list, current_id: int):
         super().__init__(timeout=300)
         self.quotes_cog = quotes_cog
@@ -34,9 +34,9 @@ class CheckQuotesView(discord.ui.View):
 
         if self.show_payload:
             payload = {k: v for k, v in quote.items() if k != '_id'}
-            embed.add_field(name='\u200b', value=f'```json\n{json.dumps(payload, indent=2)}\n```', inline=False)
+            embed.add_field(name='​', value=f'```json\n{json.dumps(payload, indent=2)}\n```', inline=False)
 
-        embed.add_field(name='\u200b', value=quote['quote'], inline=False)
+        embed.add_field(name='​', value=quote['quote'], inline=False)
 
         return embed
 
@@ -89,4 +89,21 @@ class CheckQuotesView(discord.ui.View):
     @discord.ui.button(label='Show Payload', style=ButtonStyle.gray, row=1)
     async def toggle_payload(self, button: discord.ui.Button, interaction: discord.Interaction):
         self.show_payload = not self.show_payload
+        await self.refresh(interaction)
+
+    @discord.ui.button(label='Delete', style=ButtonStyle.red, row=2)
+    async def delete_button(self, button: discord.ui.Button, interaction: discord.Interaction):
+        quote = self.quotes[self.current_id]
+        collection: AsyncCollection = await self.quotes_cog.bot.mongo.get_collection(interaction.guild_id, 'quotes')
+        await collection.delete_one({'_id': quote['_id']})
+        self.quotes.pop(self.current_id)
+
+        if not self.quotes:
+            self.disable_all_items()
+            await interaction.response.edit_message(content='No quotes remaining.', embed=None, view=self)
+            return
+
+        if self.current_id >= len(self.quotes):
+            self.current_id = len(self.quotes) - 1
+        self.show_payload = False
         await self.refresh(interaction)


### PR DESCRIPTION
## Summary
This PR refactors the quotes moderation view with improved naming, adds quote deletion capability, and reorganizes the command structure for better UX.

## Key Changes
- **Renamed class and file**: `CheckQuotesView` → `QuotesPaginateView` to better reflect its dual purpose of pagination and moderation
- **Added delete button**: New red delete button (row 2) that removes quotes from the database and updates the view accordingly
  - Handles edge cases: disables all buttons when no quotes remain, adjusts current index if needed
  - Resets payload display after deletion
- **Reorganized command structure**: Moved `/check-quotes` command to be a subcommand under the quotes group as `/quotes paginate`
  - Updated command name from `check_quotes` to `paginate_quotes` for clarity
  - Updated description to reflect both pagination and moderation capabilities
- **Fixed zero-width character**: Changed `'\u200b'` (zero-width space) to `'​'` (zero-width space character) in embed field names for consistency

## Implementation Details
- The delete button properly manages the quotes list state, including removing the current quote and adjusting the index if the deleted quote was at the end
- When all quotes are deleted, the view disables all interactive elements and displays a "No quotes remaining" message
- The payload display is automatically reset to false after deletion to provide a clean view of the next quote

https://claude.ai/code/session_01DqPyM89MUPYZJorSH3VL6q