### PR TITLE
Add quote voting (👍/👎) and restrict reroll to requester

### DIFF
--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -26,16 +26,26 @@ class QuoteView(discord.ui.View):
         self.requester_id = requester_id
         self.current_quote = quote
         self.notify = notify  # persisted across rerolls
-        self._update_star_button()
+        self._update_vote_buttons()
 
-    def _update_star_button(self):
+    def _update_vote_buttons(self):
+        up = len(self.current_quote.get('upvoted_by', []))
+        down = len(self.current_quote.get('downvoted_by', []))
         for child in self.children:
-            if isinstance(child, discord.ui.Button) and child.custom_id == 'star':
-                stars = len(self.current_quote.get('starred_by', []))
-                child.label = str(stars) if stars else None
+            if not isinstance(child, discord.ui.Button):
+                continue
+            if child.custom_id == 'upvote':
+                child.label = str(up) if up else None
+            elif child.custom_id == 'downvote':
+                child.label = str(down) if down else None
+
+    def _remove_reroll(self):
+        for child in list(self.children):
+            if isinstance(child, discord.ui.Button) and child.custom_id == 'reroll':
+                self.remove_item(child)
                 break
 
-    @discord.ui.button(label='Reroll', style=discord.ButtonStyle.secondary, emoji='🎲')
+    @discord.ui.button(label='Reroll', style=discord.ButtonStyle.secondary, emoji='🎲', custom_id='reroll')
     async def reroll(self, button: discord.ui.Button, interaction: discord.Interaction):
         if interaction.user.id != self.requester_id:
             await interaction.response.send_message('Only the user who requested this quote can reroll it.', ephemeral=True)
@@ -58,24 +68,32 @@ class QuoteView(discord.ui.View):
             return
         file = discord.File(io.BytesIO(image_bytes), filename='quote.jpg')
         content = self.quotes_cog._quote_content(self.current_quote, self.current_idx + 1, total, notify=self.notify)
-        self._update_star_button()
+        self._update_vote_buttons()
 
         await interaction.response.edit_message(content=content, attachments=[], file=file, view=self)
 
-    @discord.ui.button(emoji='⭐', style=discord.ButtonStyle.secondary, custom_id='star')
-    async def star(self, button: discord.ui.Button, interaction: discord.Interaction):
+    @discord.ui.button(emoji='👍', style=discord.ButtonStyle.secondary, custom_id='upvote')
+    async def upvote(self, button: discord.ui.Button, interaction: discord.Interaction):
+        await self._vote(interaction, 'upvoted_by', 'downvoted_by')
+
+    @discord.ui.button(emoji='👎', style=discord.ButtonStyle.secondary, custom_id='downvote')
+    async def downvote(self, button: discord.ui.Button, interaction: discord.Interaction):
+        await self._vote(interaction, 'downvoted_by', 'upvoted_by')
+
+    async def _vote(self, interaction: discord.Interaction, field: str, opposite_field: str):
         user_id = str(interaction.user.id)
-        if user_id in self.current_quote.get('starred_by', []):
-            await interaction.response.send_message('You already starred this quote.', ephemeral=True)
+        if user_id in self.current_quote.get(field, []) or user_id in self.current_quote.get(opposite_field, []):
+            await interaction.response.send_message('You already voted on this quote.', ephemeral=True)
             return
 
         collection: AsyncCollection = await self.quotes_cog.bot.mongo.get_collection(self.guild_id, 'quotes')
         await collection.update_one(
             {'_id': self.current_quote['_id']},
-            {'$push': {'starred_by': user_id}},
+            {'$push': {field: user_id}},
         )
-        self.current_quote.setdefault('starred_by', []).append(user_id)
-        self._update_star_button()
+        self.current_quote.setdefault(field, []).append(user_id)
+        self._remove_reroll()
+        self._update_vote_buttons()
 
         await interaction.response.edit_message(view=self)
 
@@ -88,7 +106,8 @@ class QuoteEntry(TypedDict):
     timestamp: int
     safe: bool
     checked: bool
-    starred_by: list[str]
+    upvoted_by: list[str]
+    downvoted_by: list[str]
 
 class Quotes(BaseCog):
     def __init__(self, bot: FriendlyFire):

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -311,7 +311,7 @@ class Quotes(BaseCog):
         submitter = quote.get('submitted_by', 'Unknown')
         embed = discord.Embed(
             title=f"Quote #{idx}/{total}",
-            color=2326507,
+            color=discord.Color.dark_theme(),
             timestamp=datetime.fromtimestamp(quote['timestamp'] / 1000),
         )
         embed.set_image(url='attachment://quote.jpg')

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -31,7 +31,7 @@ class QuoteView(discord.ui.View):
     def _update_star_button(self):
         for child in self.children:
             if isinstance(child, discord.ui.Button) and child.custom_id == 'star':
-                stars = self.current_quote.get('stars', 0)
+                stars = len(self.current_quote.get('starred_by', []))
                 child.label = str(stars) if stars else None
                 break
 
@@ -72,10 +72,9 @@ class QuoteView(discord.ui.View):
         collection: AsyncCollection = await self.quotes_cog.bot.mongo.get_collection(self.guild_id, 'quotes')
         await collection.update_one(
             {'_id': self.current_quote['_id']},
-            {'$inc': {'stars': 1}, '$push': {'starred_by': user_id}},
+            {'$push': {'starred_by': user_id}},
         )
         self.current_quote.setdefault('starred_by', []).append(user_id)
-        self.current_quote['stars'] = self.current_quote.get('stars', 0) + 1
         self._update_star_button()
 
         await interaction.response.edit_message(view=self)
@@ -89,7 +88,6 @@ class QuoteEntry(TypedDict):
     timestamp: int
     safe: bool
     checked: bool
-    stars: int
     starred_by: list[str]
 
 class Quotes(BaseCog):

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -18,13 +18,22 @@ QUOTE_REGEX = re.compile(r'\"(.+?)\"\s*-*\s*(.*)', re.MULTILINE | re.DOTALL)
 CONFIRMATION_COLOR = 0x2ea42a
 
 class QuoteView(discord.ui.View):
-    def __init__(self, quotes_cog, guild_id: int, current_idx: int, requester_id: int, notify: str = None):
+    def __init__(self, quotes_cog, guild_id: int, current_idx: int, requester_id: int, quote: dict, notify: str = None):
         super().__init__(timeout=60)
         self.quotes_cog = quotes_cog
         self.guild_id = guild_id
         self.current_idx = current_idx
         self.requester_id = requester_id
+        self.current_quote = quote
         self.notify = notify  # persisted across rerolls
+        self._update_star_button()
+
+    def _update_star_button(self):
+        for child in self.children:
+            if isinstance(child, discord.ui.Button) and child.custom_id == 'star':
+                stars = self.current_quote.get('stars', 0)
+                child.label = str(stars) if stars else None
+                break
 
     @discord.ui.button(label='Reroll', style=discord.ButtonStyle.secondary, emoji='🎲')
     async def reroll(self, button: discord.ui.Button, interaction: discord.Interaction):
@@ -39,18 +48,37 @@ class QuoteView(discord.ui.View):
             await interaction.response.send_message('No other safe quotes available.', ephemeral=True)
             return
 
-        self.current_idx, quote = random.choice(safe_quotes)
+        self.current_idx, self.current_quote = random.choice(safe_quotes)
         total = len(all_quotes)
 
         try:
-            image_bytes = await generate_quote_image(quote['quote'], quote.get('author', ''), self.quotes_cog.config.get('fontPath'))
+            image_bytes = await generate_quote_image(self.current_quote['quote'], self.current_quote.get('author', ''), self.quotes_cog.config.get('fontPath'))
         except (aiohttp.ClientError, asyncio.TimeoutError):
             await interaction.response.send_message('Failed to fetch background image. Please try again.', ephemeral=True)
             return
         file = discord.File(io.BytesIO(image_bytes), filename='quote.jpg')
-        content = self.quotes_cog._quote_content(quote, self.current_idx + 1, total, notify=self.notify)
+        content = self.quotes_cog._quote_content(self.current_quote, self.current_idx + 1, total, notify=self.notify)
+        self._update_star_button()
 
         await interaction.response.edit_message(content=content, attachments=[], file=file, view=self)
+
+    @discord.ui.button(emoji='⭐', style=discord.ButtonStyle.secondary, custom_id='star')
+    async def star(self, button: discord.ui.Button, interaction: discord.Interaction):
+        user_id = str(interaction.user.id)
+        if user_id in self.current_quote.get('starred_by', []):
+            await interaction.response.send_message('You already starred this quote.', ephemeral=True)
+            return
+
+        collection: AsyncCollection = await self.quotes_cog.bot.mongo.get_collection(self.guild_id, 'quotes')
+        await collection.update_one(
+            {'_id': self.current_quote['_id']},
+            {'$inc': {'stars': 1}, '$push': {'starred_by': user_id}},
+        )
+        self.current_quote.setdefault('starred_by', []).append(user_id)
+        self.current_quote['stars'] = self.current_quote.get('stars', 0) + 1
+        self._update_star_button()
+
+        await interaction.response.edit_message(view=self)
 
 
 class QuoteEntry(TypedDict):
@@ -61,6 +89,8 @@ class QuoteEntry(TypedDict):
     timestamp: int
     safe: bool
     checked: bool
+    stars: int
+    starred_by: list[str]
 
 class Quotes(BaseCog):
     def __init__(self, bot: FriendlyFire):
@@ -126,7 +156,7 @@ class Quotes(BaseCog):
             return
         file = discord.File(io.BytesIO(image_bytes), filename='quote.jpg')
         notify = ctx.author.mention if use_reply_channel else None
-        view = QuoteView(self, ctx.guild_id, idx, ctx.author.id, notify)
+        view = QuoteView(self, ctx.guild_id, idx, ctx.author.id, quote, notify)
         content = self._quote_content(quote, idx + 1, total, notify=notify)
 
         if use_reply_channel:

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -18,15 +18,19 @@ QUOTE_REGEX = re.compile(r'\"(.+?)\"\s*-*\s*(.*)', re.MULTILINE | re.DOTALL)
 CONFIRMATION_COLOR = 0x2ea42a
 
 class QuoteView(discord.ui.View):
-    def __init__(self, quotes_cog, guild_id: int, current_idx: int, notify: str = None):
+    def __init__(self, quotes_cog, guild_id: int, current_idx: int, requester_id: int, notify: str = None):
         super().__init__(timeout=60)
         self.quotes_cog = quotes_cog
         self.guild_id = guild_id
         self.current_idx = current_idx
+        self.requester_id = requester_id
         self.notify = notify  # persisted across rerolls
 
     @discord.ui.button(label='Reroll', style=discord.ButtonStyle.secondary, emoji='🎲')
     async def reroll(self, button: discord.ui.Button, interaction: discord.Interaction):
+        if interaction.user.id != self.requester_id:
+            await interaction.response.send_message('Only the user who requested this quote can reroll it.', ephemeral=True)
+            return
         collection: AsyncCollection = await self.quotes_cog.bot.mongo.get_collection(self.guild_id, 'quotes')
         all_quotes = await collection.find({}).sort('timestamp', 1).to_list()
 
@@ -122,7 +126,7 @@ class Quotes(BaseCog):
             return
         file = discord.File(io.BytesIO(image_bytes), filename='quote.jpg')
         notify = ctx.author.mention if use_reply_channel else None
-        view = QuoteView(self, ctx.guild_id, idx, notify)
+        view = QuoteView(self, ctx.guild_id, idx, ctx.author.id, notify)
         content = self._quote_content(quote, idx + 1, total, notify=notify)
 
         if use_reply_channel:

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -35,9 +35,9 @@ class QuoteView(discord.ui.View):
             if not isinstance(child, discord.ui.Button):
                 continue
             if child.custom_id == 'upvote':
-                child.label = str(up) if up else None
+                child.label = str(up)
             elif child.custom_id == 'downvote':
-                child.label = str(down) if down else None
+                child.label = str(down)
 
     def _remove_reroll(self):
         for child in list(self.children):
@@ -82,15 +82,17 @@ class QuoteView(discord.ui.View):
 
     async def _vote(self, interaction: discord.Interaction, field: str, opposite_field: str):
         user_id = str(interaction.user.id)
-        if user_id in self.current_quote.get(field, []) or user_id in self.current_quote.get(opposite_field, []):
+        if user_id in self.current_quote.get(field, []):
             await interaction.response.send_message('You already voted on this quote.', ephemeral=True)
             return
 
         collection: AsyncCollection = await self.quotes_cog.bot.mongo.get_collection(self.guild_id, 'quotes')
-        await collection.update_one(
-            {'_id': self.current_quote['_id']},
-            {'$push': {field: user_id}},
-        )
+        update: dict = {'$push': {field: user_id}}
+        if user_id in self.current_quote.get(opposite_field, []):
+            update['$pull'] = {opposite_field: user_id}
+            self.current_quote[opposite_field].remove(user_id)
+
+        await collection.update_one({'_id': self.current_quote['_id']}, update)
         self.current_quote.setdefault(field, []).append(user_id)
         self._remove_reroll()
         self._update_vote_buttons()

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -67,10 +67,10 @@ class QuoteView(discord.ui.View):
             await interaction.response.send_message('Failed to fetch background image. Please try again.', ephemeral=True)
             return
         file = discord.File(io.BytesIO(image_bytes), filename='quote.jpg')
-        content = self.quotes_cog._quote_content(self.current_quote, self.current_idx + 1, total, notify=self.notify)
+        embed = self.quotes_cog._quote_embed(self.current_quote, self.current_idx + 1, total)
         self._update_vote_buttons()
 
-        await interaction.response.edit_message(content=content, attachments=[], file=file, view=self)
+        await interaction.response.edit_message(content=self.notify, attachments=[], file=file, embed=embed, view=self)
 
     @discord.ui.button(emoji='👍', style=discord.ButtonStyle.secondary, custom_id='upvote')
     async def upvote(self, button: discord.ui.Button, interaction: discord.Interaction):
@@ -176,13 +176,13 @@ class Quotes(BaseCog):
         file = discord.File(io.BytesIO(image_bytes), filename='quote.jpg')
         notify = ctx.author.mention if use_reply_channel else None
         view = QuoteView(self, ctx.guild_id, idx, ctx.author.id, quote, notify)
-        content = self._quote_content(quote, idx + 1, total, notify=notify)
+        embed = self._quote_embed(quote, idx + 1, total)
 
         if use_reply_channel:
-            await reply_channel.send(content=content, file=file, view=view)
+            await reply_channel.send(content=notify, file=file, embed=embed, view=view)
             await ctx.respond(f"Quote sent to {reply_channel.mention}.", ephemeral=True)
         else:
-            await ctx.respond(content=content, file=file, view=view)
+            await ctx.respond(file=file, embed=embed, view=view)
 
     @quotesGroup.command(name="paginate", description="Open the quote paginator/moderation view.")
     @discord.option(name="id", parameter_name="quote_id", description="Id of the quote to start at", required=False, input_type=int)
@@ -307,11 +307,16 @@ class Quotes(BaseCog):
         embed.set_footer(text=f'Saved by {entry["submitted_by"]}. Quote #{idx + 1}/{len(all_quotes)}')
         await message.channel.send(embed=embed)
 
-    def _quote_content(self, quote: dict, idx: int, total: int, notify: str = None) -> str:
-        submitter = f"<@{quote['submitted_by_id']}>" if quote.get('submitted_by_id') else quote.get('submitted_by', 'Unknown')
-        date = discord.utils.format_dt(datetime.fromtimestamp(quote['timestamp'] / 1000), style='D')
-        info = f"Quote #{idx}/{total} — submitted by {submitter} on {date}"
-        return f"{notify}\n{info}" if notify else info
+    def _quote_embed(self, quote: dict, idx: int, total: int) -> discord.Embed:
+        submitter = quote.get('submitted_by', 'Unknown')
+        embed = discord.Embed(
+            title=f"Quote #{idx}/{total}",
+            color=2326507,
+            timestamp=datetime.fromtimestamp(quote['timestamp'] / 1000),
+        )
+        embed.set_image(url='attachment://quote.jpg')
+        embed.set_footer(text=f"submitted by {submitter}")
+        return embed
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Reroll button on `/quote` is now restricted to the user who invoked the command
- Replaced the star button with 👍 / 👎 voting buttons
- Vote counts always shown (including 0); switching sides moves your vote atomically
- First vote removes the reroll button so the quote stays visible for everyone to rate

## MongoDB schema changes

Each quote document gains two new fields:
- `upvoted_by: list[str]` — user IDs who upvoted
- `downvoted_by: list[str]` — user IDs who downvoted

No migration needed — fields are absent until first vote and defaulted to `[]` in code.

## Test plan

- [ ] `/quote` — reroll works for invoker, blocked for others
- [ ] 👍 / 👎 show count 0 initially
- [ ] Voting once locks in; voting the opposite side switches the vote atomically
- [ ] Clicking the same button twice shows ephemeral "already voted"
- [ ] First vote removes the reroll button
- [ ] Rerolling resets vote counts to reflect the new quote
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvvDjyRJvYPSMQbjnrbpoG)_