### PR TITLE
Improve quote view timeout handling and vote display

### DIFF
--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -18,11 +18,12 @@ QUOTE_REGEX = re.compile(r'\"(.+?)\"\s*-*\s*(.*)', re.MULTILINE | re.DOTALL)
 CONFIRMATION_COLOR = 0x2ea42a
 
 class QuoteView(discord.ui.View):
-    def __init__(self, quotes_cog, guild_id: int, current_idx: int, requester_id: int, quote: dict, notify: str = None):
-        super().__init__(timeout=300)
+    def __init__(self, quotes_cog, guild_id: int, current_idx: int, total: int, requester_id: int, quote: dict, notify: str = None):
+        super().__init__(timeout=600)
         self.quotes_cog = quotes_cog
         self.guild_id = guild_id
         self.current_idx = current_idx
+        self.total = total
         self.requester_id = requester_id
         self.current_quote = quote
         self.notify = notify  # persisted across rerolls
@@ -104,8 +105,9 @@ class QuoteView(discord.ui.View):
         self.current_quote.setdefault(field, []).append(user_id)
         self._remove_reroll()
         self._update_vote_buttons()
+        embed = self.quotes_cog._quote_embed(self.current_quote, self.current_idx + 1, self.total)
 
-        await interaction.response.edit_message(view=self)
+        await interaction.response.edit_message(embed=embed, view=self)
 
 
 class QuoteEntry(TypedDict):
@@ -183,7 +185,7 @@ class Quotes(BaseCog):
             return
         file = discord.File(io.BytesIO(image_bytes), filename='quote.jpg')
         notify = ctx.author.mention if use_reply_channel else None
-        view = QuoteView(self, ctx.guild_id, idx, ctx.author.id, quote, notify)
+        view = QuoteView(self, ctx.guild_id, idx, total, ctx.author.id, quote, notify)
         embed = self._quote_embed(quote, idx + 1, total)
 
         if use_reply_channel:
@@ -319,13 +321,15 @@ class Quotes(BaseCog):
 
     def _quote_embed(self, quote: dict, idx: int, total: int) -> discord.Embed:
         submitter = quote.get('submitted_by', 'Unknown')
+        up = len(quote.get('upvoted_by', []))
+        down = len(quote.get('downvoted_by', []))
         embed = discord.Embed(
             title=f"Quote #{idx}/{total}",
             color=discord.Color.dark_theme(),
             timestamp=datetime.fromtimestamp(quote['timestamp'] / 1000),
         )
         embed.set_image(url='attachment://quote.jpg')
-        embed.set_footer(text=f"submitted by {submitter}")
+        embed.set_footer(text=f"submitted by {submitter}  •  👍 {up}  👎 {down}")
         return embed
 
     @commands.Cog.listener()

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -69,7 +69,7 @@ class QuoteView(discord.ui.View):
             return
 
         self.current_idx, self.current_quote = random.choice(safe_quotes)
-        total = len(all_quotes)
+        self.total = len(all_quotes)
 
         try:
             image_bytes = await generate_quote_image(self.current_quote['quote'], self.current_quote.get('author', ''), self.quotes_cog.config.get('fontPath'))
@@ -77,7 +77,7 @@ class QuoteView(discord.ui.View):
             await interaction.response.send_message('Failed to fetch background image. Please try again.', ephemeral=True)
             return
         file = discord.File(io.BytesIO(image_bytes), filename='quote.jpg')
-        embed = self.quotes_cog._quote_embed(self.current_quote, self.current_idx + 1, total)
+        embed = self.quotes_cog._quote_embed(self.current_quote, self.current_idx + 1, self.total)
         self._update_vote_buttons()
 
         await interaction.response.edit_message(content=self.notify, attachments=[], file=file, embed=embed, view=self)

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -50,7 +50,8 @@ class QuoteView(discord.ui.View):
     async def on_timeout(self):
         if self.message:
             try:
-                await self.message.edit(view=None)
+                embed = self.quotes_cog._quote_embed(self.current_quote, self.current_idx + 1, self.total, show_votes=True)
+                await self.message.edit(embed=embed, view=None)
             except discord.NotFound:
                 pass
 
@@ -105,9 +106,8 @@ class QuoteView(discord.ui.View):
         self.current_quote.setdefault(field, []).append(user_id)
         self._remove_reroll()
         self._update_vote_buttons()
-        embed = self.quotes_cog._quote_embed(self.current_quote, self.current_idx + 1, self.total)
 
-        await interaction.response.edit_message(embed=embed, view=self)
+        await interaction.response.edit_message(view=self)
 
 
 class QuoteEntry(TypedDict):
@@ -319,17 +319,20 @@ class Quotes(BaseCog):
         embed.set_footer(text=f'Saved by {entry["submitted_by"]}. Quote #{idx + 1}/{len(all_quotes)}')
         await message.channel.send(embed=embed)
 
-    def _quote_embed(self, quote: dict, idx: int, total: int) -> discord.Embed:
+    def _quote_embed(self, quote: dict, idx: int, total: int, show_votes: bool = False) -> discord.Embed:
         submitter = quote.get('submitted_by', 'Unknown')
-        up = len(quote.get('upvoted_by', []))
-        down = len(quote.get('downvoted_by', []))
         embed = discord.Embed(
             title=f"Quote #{idx}/{total}",
             color=discord.Color.dark_theme(),
             timestamp=datetime.fromtimestamp(quote['timestamp'] / 1000),
         )
         embed.set_image(url='attachment://quote.jpg')
-        embed.set_footer(text=f"submitted by {submitter}  •  👍 {up}  👎 {down}")
+        if show_votes:
+            up = len(quote.get('upvoted_by', []))
+            down = len(quote.get('downvoted_by', []))
+            embed.set_footer(text=f"submitted by {submitter}  •  👍 {up}  👎 {down}")
+        else:
+            embed.set_footer(text=f"submitted by {submitter}")
         return embed
 
     @commands.Cog.listener()

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -19,13 +19,14 @@ CONFIRMATION_COLOR = 0x2ea42a
 
 class QuoteView(discord.ui.View):
     def __init__(self, quotes_cog, guild_id: int, current_idx: int, requester_id: int, quote: dict, notify: str = None):
-        super().__init__(timeout=60)
+        super().__init__(timeout=300)
         self.quotes_cog = quotes_cog
         self.guild_id = guild_id
         self.current_idx = current_idx
         self.requester_id = requester_id
         self.current_quote = quote
         self.notify = notify  # persisted across rerolls
+        self.message: discord.Message = None
         self._update_vote_buttons()
 
     def _update_vote_buttons(self):
@@ -44,6 +45,13 @@ class QuoteView(discord.ui.View):
             if isinstance(child, discord.ui.Button) and child.custom_id == 'reroll':
                 self.remove_item(child)
                 break
+
+    async def on_timeout(self):
+        if self.message:
+            try:
+                await self.message.edit(view=None)
+            except discord.NotFound:
+                pass
 
     @discord.ui.button(label='Reroll', style=discord.ButtonStyle.secondary, emoji='🎲', custom_id='reroll')
     async def reroll(self, button: discord.ui.Button, interaction: discord.Interaction):
@@ -179,10 +187,11 @@ class Quotes(BaseCog):
         embed = self._quote_embed(quote, idx + 1, total)
 
         if use_reply_channel:
-            await reply_channel.send(content=notify, file=file, embed=embed, view=view)
+            view.message = await reply_channel.send(content=notify, file=file, embed=embed, view=view)
             await ctx.respond(f"Quote sent to {reply_channel.mention}.", ephemeral=True)
         else:
             await ctx.respond(file=file, embed=embed, view=view)
+            view.message = await ctx.interaction.original_response()
 
     @quotesGroup.command(name="paginate", description="Open the quote paginator/moderation view.")
     @discord.option(name="id", parameter_name="quote_id", description="Id of the quote to start at", required=False, input_type=int)
@@ -204,6 +213,7 @@ class Quotes(BaseCog):
 
         view = QuotesPaginateView(self, quotes, idx)
         await ctx.respond(embed=view.get_embed(), view=view)
+        view.message = await ctx.interaction.original_response()
 
     @discord.slash_command(name="crawl-missing-quotes", description="Crawl the quote channel to backfill missing quotes.", default_member_permissions=discord.Permissions(administrator=True), guild_only=True)
     async def crawl_missing_quotes(self, ctx: discord.ApplicationContext):

--- a/cogs/quotes/quotes_paginate_view.py
+++ b/cogs/quotes/quotes_paginate_view.py
@@ -13,6 +13,7 @@ class QuotesPaginateView(discord.ui.View):
         self.quotes = quotes
         self.current_id = current_id
         self.show_payload = False
+        self.message: discord.Message = None
         self.update_buttons()
 
     def get_embed(self) -> discord.Embed:
@@ -51,6 +52,13 @@ class QuotesPaginateView(discord.ui.View):
                 child.style = ButtonStyle.primary if not quote.get('safe') else ButtonStyle.secondary
             elif child.label in ('Show Payload', 'Hide Payload'):
                 child.label = 'Hide Payload' if self.show_payload else 'Show Payload'
+
+    async def on_timeout(self):
+        if self.message:
+            try:
+                await self.message.edit(view=None)
+            except discord.NotFound:
+                pass
 
     async def refresh(self, interaction: discord.Interaction):
         self.update_buttons()

--- a/cogs/quotes/quotes_paginate_view.py
+++ b/cogs/quotes/quotes_paginate_view.py
@@ -8,7 +8,7 @@ from pymongo.asynchronous.collection import AsyncCollection
 
 class QuotesPaginateView(discord.ui.View):
     def __init__(self, quotes_cog, quotes: list, current_id: int):
-        super().__init__(timeout=300)
+        super().__init__(timeout=600)
         self.quotes_cog = quotes_cog
         self.quotes = quotes
         self.current_id = current_id


### PR DESCRIPTION
## Summary
Enhanced the quote display views to better handle timeouts and provide improved user feedback by persisting message references and displaying vote counts when views expire.

## Key Changes
- **Extended view timeouts**: Increased `QuoteView` timeout from 60s to 600s and `QuotesPaginateView` timeout from 300s to 600s to allow longer interaction windows
- **Message persistence**: Added `message` attribute to both `QuoteView` and `QuotesPaginateView` to track the Discord message object, enabling proper cleanup on timeout
- **Timeout handlers**: Implemented `on_timeout()` methods in both view classes that:
  - Remove interactive buttons when the view expires
  - Display final vote counts in the quote embed footer when `QuoteView` times out
  - Gracefully handle cases where the message has been deleted
- **Vote display enhancement**: Added optional `show_votes` parameter to `_quote_embed()` method to display upvote/downvote counts in the footer (👍/👎 format)
- **Message tracking**: Updated quote command handlers to capture and store message references for both direct responses and channel sends, enabling proper timeout cleanup

## Implementation Details
- Vote counts are only displayed on timeout, keeping the initial embed clean
- All timeout handlers include error handling for `discord.NotFound` exceptions to handle deleted messages gracefully
- The `QuoteView` now requires a `total` parameter to properly display quote pagination in timeout scenarios

https://claude.ai/code/session_01N9fHBMw5ixVAbFGodzQnZP