### PR TITLE
fix: rename refresh to _refresh_embed to avoid shadowing View.refresh

### DIFF
--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -25,7 +25,7 @@ class Invites(BaseCog):
             "invitesChannel": None,
         })
 
-    greetingsGroup = discord.SlashCommandGroup(name="greetings", description="manage greetings", default_member_permissions=discord.Permissions(administrator=True), guild_only=True)
+    greetingsGroup = discord.SlashCommandGroup(name="greetings", description="manage greetings", default_member_permissions=discord.Permissions(administrator=True), contexts=[discord.InteractionContextType.guild])
 
     @greetingsGroup.command(name="create", description="create a greeting")
     @option(name="text", description="greeting text", required=True)

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -129,7 +129,7 @@ class Quotes(BaseCog):
             'fontPath': 'assets/fonts/PlayfairDisplay-Italic.ttf',
         })
 
-    quotesGroup = discord.SlashCommandGroup(name="quotes", description="manage quotes config", default_member_permissions=discord.Permissions(administrator=True), guild_only=True)
+    quotesGroup = discord.SlashCommandGroup(name="quotes", description="manage quotes config", default_member_permissions=discord.Permissions(administrator=True), contexts=[discord.InteractionContextType.guild])
 
     @quotesGroup.command(name="set-capture-channel", description="Set the channel to listen for new quotes")
     @discord.option(name="channel", required=True, input_type=discord.SlashCommandOptionType.channel)

--- a/cogs/quotes/quotes_paginate_view.py
+++ b/cogs/quotes/quotes_paginate_view.py
@@ -60,7 +60,7 @@ class QuotesPaginateView(discord.ui.View):
             except discord.NotFound:
                 pass
 
-    async def _respond(self, interaction: discord.Interaction):
+    async def _refresh_embed(self, interaction: discord.Interaction):
         self.update_buttons()
         await interaction.response.edit_message(embed=self.get_embed(), view=self)
 
@@ -71,7 +71,7 @@ class QuotesPaginateView(discord.ui.View):
         await collection.update_one({'_id': quote['_id']}, {'$set': {'safe': True, 'checked': True}})
         quote['safe'] = True
         quote['checked'] = True
-        await self._respond(interaction)
+        await self._refresh_embed(interaction)
 
     @discord.ui.button(label='Unsafe', style=ButtonStyle.secondary, row=0)
     async def unsafe_button(self, button: discord.ui.Button, interaction: discord.Interaction):
@@ -80,24 +80,24 @@ class QuotesPaginateView(discord.ui.View):
         await collection.update_one({'_id': quote['_id']}, {'$set': {'safe': False, 'checked': True}})
         quote['safe'] = False
         quote['checked'] = True
-        await self._respond(interaction)
+        await self._refresh_embed(interaction)
 
     @discord.ui.button(label='Prev', style=ButtonStyle.gray, row=1)
     async def prev_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         self.current_id = (self.current_id - 1) % len(self.quotes)
         self.show_payload = False
-        await self._respond(interaction)
+        await self._refresh_embed(interaction)
 
     @discord.ui.button(label='Next', style=ButtonStyle.gray, row=1)
     async def next_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         self.current_id = (self.current_id + 1) % len(self.quotes)
         self.show_payload = False
-        await self._respond(interaction)
+        await self._refresh_embed(interaction)
 
     @discord.ui.button(label='Show Payload', style=ButtonStyle.gray, row=1)
     async def toggle_payload(self, button: discord.ui.Button, interaction: discord.Interaction):
         self.show_payload = not self.show_payload
-        await self._respond(interaction)
+        await self._refresh_embed(interaction)
 
     @discord.ui.button(label='Delete', style=ButtonStyle.red, row=2)
     async def delete_button(self, button: discord.ui.Button, interaction: discord.Interaction):
@@ -114,4 +114,4 @@ class QuotesPaginateView(discord.ui.View):
         if self.current_id >= len(self.quotes):
             self.current_id = len(self.quotes) - 1
         self.show_payload = False
-        await self._respond(interaction)
+        await self._refresh_embed(interaction)

--- a/cogs/quotes/quotes_paginate_view.py
+++ b/cogs/quotes/quotes_paginate_view.py
@@ -60,7 +60,7 @@ class QuotesPaginateView(discord.ui.View):
             except discord.NotFound:
                 pass
 
-    async def refresh(self, interaction: discord.Interaction):
+    async def _respond(self, interaction: discord.Interaction):
         self.update_buttons()
         await interaction.response.edit_message(embed=self.get_embed(), view=self)
 
@@ -71,7 +71,7 @@ class QuotesPaginateView(discord.ui.View):
         await collection.update_one({'_id': quote['_id']}, {'$set': {'safe': True, 'checked': True}})
         quote['safe'] = True
         quote['checked'] = True
-        await self.refresh(interaction)
+        await self._respond(interaction)
 
     @discord.ui.button(label='Unsafe', style=ButtonStyle.secondary, row=0)
     async def unsafe_button(self, button: discord.ui.Button, interaction: discord.Interaction):
@@ -80,24 +80,24 @@ class QuotesPaginateView(discord.ui.View):
         await collection.update_one({'_id': quote['_id']}, {'$set': {'safe': False, 'checked': True}})
         quote['safe'] = False
         quote['checked'] = True
-        await self.refresh(interaction)
+        await self._respond(interaction)
 
     @discord.ui.button(label='Prev', style=ButtonStyle.gray, row=1)
     async def prev_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         self.current_id = (self.current_id - 1) % len(self.quotes)
         self.show_payload = False
-        await self.refresh(interaction)
+        await self._respond(interaction)
 
     @discord.ui.button(label='Next', style=ButtonStyle.gray, row=1)
     async def next_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         self.current_id = (self.current_id + 1) % len(self.quotes)
         self.show_payload = False
-        await self.refresh(interaction)
+        await self._respond(interaction)
 
     @discord.ui.button(label='Show Payload', style=ButtonStyle.gray, row=1)
     async def toggle_payload(self, button: discord.ui.Button, interaction: discord.Interaction):
         self.show_payload = not self.show_payload
-        await self.refresh(interaction)
+        await self._respond(interaction)
 
     @discord.ui.button(label='Delete', style=ButtonStyle.red, row=2)
     async def delete_button(self, button: discord.ui.Button, interaction: discord.Interaction):
@@ -114,4 +114,4 @@ class QuotesPaginateView(discord.ui.View):
         if self.current_id >= len(self.quotes):
             self.current_id = len(self.quotes) - 1
         self.show_payload = False
-        await self.refresh(interaction)
+        await self._respond(interaction)

--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -25,7 +25,7 @@ class Topic(BaseCog):
         if not self.config.get('topicTypes'):
             self.log('No topic types configured in config/topic.json — topic commands will be unavailable.')
 
-    topicGroup = discord.SlashCommandGroup(name="topic", description="manage topics", default_member_permissions=discord.Permissions(administrator=True), guild_only=True)
+    topicGroup = discord.SlashCommandGroup(name="topic", description="manage topics", default_member_permissions=discord.Permissions(administrator=True), contexts=[discord.InteractionContextType.guild])
 
     async def get_topic_types(self, ctx: discord.AutocompleteContext):
         return list(self.config.get('topicTypes').keys())


### PR DESCRIPTION
## Summary

- `discord.ui.View` has an internal synchronous `refresh(components)` method used by py-cord to rebuild button state
- `QuotesPaginateView` defined `async def refresh(interaction)` which shadowed it — py-cord called it with a components list, got an unawaited coroutine back, and the GC emitted `RuntimeWarning: coroutine 'QuotesPaginateView.refresh' was never awaited`
- Renames the method to `_refresh_embed` across definition and all six call sites

## Test plan

- [ ] Bot starts without `RuntimeWarning` about unawaited coroutine
- [ ] All quote pagination buttons (Safe, Unsafe, Prev, Next, Show Payload, Delete) correctly update the embed

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGA7pMVByyuMi3cyt51gqD)_