### PR TITLE
feat: forward Python warnings to owner DM

### DIFF
--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -25,7 +25,7 @@ class Invites(BaseCog):
             "invitesChannel": None,
         })
 
-    greetingsGroup = discord.SlashCommandGroup(name="greetings", description="manage greetings", default_member_permissions=discord.Permissions(administrator=True), guild_only=True)
+    greetingsGroup = discord.SlashCommandGroup(name="greetings", description="manage greetings", default_member_permissions=discord.Permissions(administrator=True), contexts=[discord.InteractionContextType.guild])
 
     @greetingsGroup.command(name="create", description="create a greeting")
     @option(name="text", description="greeting text", required=True)

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -129,7 +129,7 @@ class Quotes(BaseCog):
             'fontPath': 'assets/fonts/PlayfairDisplay-Italic.ttf',
         })
 
-    quotesGroup = discord.SlashCommandGroup(name="quotes", description="manage quotes config", default_member_permissions=discord.Permissions(administrator=True), guild_only=True)
+    quotesGroup = discord.SlashCommandGroup(name="quotes", description="manage quotes config", default_member_permissions=discord.Permissions(administrator=True), contexts=[discord.InteractionContextType.guild])
 
     @quotesGroup.command(name="set-capture-channel", description="Set the channel to listen for new quotes")
     @discord.option(name="channel", required=True, input_type=discord.SlashCommandOptionType.channel)

--- a/cogs/quotes/quotes_paginate_view.py
+++ b/cogs/quotes/quotes_paginate_view.py
@@ -60,7 +60,7 @@ class QuotesPaginateView(discord.ui.View):
             except discord.NotFound:
                 pass
 
-    async def refresh(self, interaction: discord.Interaction):
+    async def _respond(self, interaction: discord.Interaction):
         self.update_buttons()
         await interaction.response.edit_message(embed=self.get_embed(), view=self)
 
@@ -71,7 +71,7 @@ class QuotesPaginateView(discord.ui.View):
         await collection.update_one({'_id': quote['_id']}, {'$set': {'safe': True, 'checked': True}})
         quote['safe'] = True
         quote['checked'] = True
-        await self.refresh(interaction)
+        await self._respond(interaction)
 
     @discord.ui.button(label='Unsafe', style=ButtonStyle.secondary, row=0)
     async def unsafe_button(self, button: discord.ui.Button, interaction: discord.Interaction):
@@ -80,24 +80,24 @@ class QuotesPaginateView(discord.ui.View):
         await collection.update_one({'_id': quote['_id']}, {'$set': {'safe': False, 'checked': True}})
         quote['safe'] = False
         quote['checked'] = True
-        await self.refresh(interaction)
+        await self._respond(interaction)
 
     @discord.ui.button(label='Prev', style=ButtonStyle.gray, row=1)
     async def prev_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         self.current_id = (self.current_id - 1) % len(self.quotes)
         self.show_payload = False
-        await self.refresh(interaction)
+        await self._respond(interaction)
 
     @discord.ui.button(label='Next', style=ButtonStyle.gray, row=1)
     async def next_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         self.current_id = (self.current_id + 1) % len(self.quotes)
         self.show_payload = False
-        await self.refresh(interaction)
+        await self._respond(interaction)
 
     @discord.ui.button(label='Show Payload', style=ButtonStyle.gray, row=1)
     async def toggle_payload(self, button: discord.ui.Button, interaction: discord.Interaction):
         self.show_payload = not self.show_payload
-        await self.refresh(interaction)
+        await self._respond(interaction)
 
     @discord.ui.button(label='Delete', style=ButtonStyle.red, row=2)
     async def delete_button(self, button: discord.ui.Button, interaction: discord.Interaction):
@@ -114,4 +114,4 @@ class QuotesPaginateView(discord.ui.View):
         if self.current_id >= len(self.quotes):
             self.current_id = len(self.quotes) - 1
         self.show_payload = False
-        await self.refresh(interaction)
+        await self._respond(interaction)

--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -25,7 +25,7 @@ class Topic(BaseCog):
         if not self.config.get('topicTypes'):
             self.log('No topic types configured in config/topic.json — topic commands will be unavailable.')
 
-    topicGroup = discord.SlashCommandGroup(name="topic", description="manage topics", default_member_permissions=discord.Permissions(administrator=True), guild_only=True)
+    topicGroup = discord.SlashCommandGroup(name="topic", description="manage topics", default_member_permissions=discord.Permissions(administrator=True), contexts=[discord.InteractionContextType.guild])
 
     async def get_topic_types(self, ctx: discord.AutocompleteContext):
         return list(self.config.get('topicTypes').keys())

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,5 +1,7 @@
+import asyncio
 import io
 import traceback
+import warnings
 
 import discord
 from discord.ext import commands
@@ -10,6 +12,20 @@ class FriendlyFire(commands.Bot):
         super().__init__(intents=discord.Intents.all())
         self.mongo = Mongo(mongo_uri)
         self._owner: discord.User = None
+        self._pending_warnings: list[tuple[str, str]] = []
+        self._setup_warning_hook()
+
+    def _setup_warning_hook(self):
+        original = warnings.showwarning
+        def hook(message, category, filename, lineno, file=None, line=None):
+            original(message, category, filename, lineno, file, line)
+            header = f'**Warning: `{category.__name__}`**'
+            text = f'{filename}:{lineno}: {category.__name__}: {message}'
+            if self._owner is not None:
+                asyncio.ensure_future(self._dm_owner(header, text))
+            else:
+                self._pending_warnings.append((header, text))
+        warnings.showwarning = hook
 
     async def on_ready(self):
         print(f'Logged in as {self.user.name} ({self.user.id})')
@@ -21,6 +37,10 @@ class FriendlyFire(commands.Bot):
 
         app_info = await self.application_info()
         self._owner = app_info.owner
+
+        for header, text in self._pending_warnings:
+            await self._dm_owner(header, text)
+        self._pending_warnings.clear()
 
     async def _dm_owner(self, header: str, tb: str):
         if self._owner is None:


### PR DESCRIPTION
## Summary

- The existing `_dm_owner` system only covered Discord exceptions (`on_application_command_error`, `on_error`) — Python `warnings` module calls were invisible to it
- Installs a `warnings.showwarning` hook in `__init__` that buffers warnings emitted before `on_ready` (e.g. startup deprecations during `load_extension`) and drains them once the owner is known
- Warnings raised at runtime (after `on_ready`) are forwarded immediately via `asyncio.ensure_future`

## Test plan

- [ ] Startup warnings (e.g. deprecations) are received as a DM once the bot is ready
- [ ] Runtime warnings are received as a DM shortly after they occur
- [ ] Normal bot operation is unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGA7pMVByyuMi3cyt51gqD)_