### PR TITLE
fix: replace deprecated guild_only with contexts in SlashCommandGroups

### DIFF
--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -25,7 +25,7 @@ class Invites(BaseCog):
             "invitesChannel": None,
         })
 
-    greetingsGroup = discord.SlashCommandGroup(name="greetings", description="manage greetings", default_member_permissions=discord.Permissions(administrator=True), guild_only=True)
+    greetingsGroup = discord.SlashCommandGroup(name="greetings", description="manage greetings", default_member_permissions=discord.Permissions(administrator=True), contexts=[discord.InteractionContextType.guild])
 
     @greetingsGroup.command(name="create", description="create a greeting")
     @option(name="text", description="greeting text", required=True)

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -129,7 +129,7 @@ class Quotes(BaseCog):
             'fontPath': 'assets/fonts/PlayfairDisplay-Italic.ttf',
         })
 
-    quotesGroup = discord.SlashCommandGroup(name="quotes", description="manage quotes config", default_member_permissions=discord.Permissions(administrator=True), guild_only=True)
+    quotesGroup = discord.SlashCommandGroup(name="quotes", description="manage quotes config", default_member_permissions=discord.Permissions(administrator=True), contexts=[discord.InteractionContextType.guild])
 
     @quotesGroup.command(name="set-capture-channel", description="Set the channel to listen for new quotes")
     @discord.option(name="channel", required=True, input_type=discord.SlashCommandOptionType.channel)

--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -25,7 +25,7 @@ class Topic(BaseCog):
         if not self.config.get('topicTypes'):
             self.log('No topic types configured in config/topic.json — topic commands will be unavailable.')
 
-    topicGroup = discord.SlashCommandGroup(name="topic", description="manage topics", default_member_permissions=discord.Permissions(administrator=True), guild_only=True)
+    topicGroup = discord.SlashCommandGroup(name="topic", description="manage topics", default_member_permissions=discord.Permissions(administrator=True), contexts=[discord.InteractionContextType.guild])
 
     async def get_topic_types(self, ctx: discord.AutocompleteContext):
         return list(self.config.get('topicTypes').keys())


### PR DESCRIPTION
## Summary

- `guild_only=True` is deprecated since py-cord 2.6
- Replaces it with `contexts=[discord.InteractionContextType.guild]` in `invites.py`, `quotes.py`, and `topic.py`

## Test plan

- [ ] Bot starts without `DeprecationWarning` for `guild_only`
- [ ] Guild-only slash commands (`/greetings`, `/quotes`, `/topic`) remain restricted to guild contexts

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGA7pMVByyuMi3cyt51gqD)_