### PR TITLE
feat: Starboard & per-guild localisation [superseded]

### DIFF
--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -121,11 +121,12 @@ class Invites(BaseCog):
                 greetings = await greetings_collection.find({}).to_list()
                 greeting_text = random.choice(greetings)['greeting'] if greetings else None
 
+                inviter_part = self.t('invites.invited_by', member.guild.id, inviter_id=inviter_id) if inviter_id is not None else ""
                 embed = discord.Embed(
-                    title="Bienvenue!",
+                    title=self.t('invites.welcome_title', member.guild.id),
                     thumbnail=member.avatar.url if member.avatar else None,
                     color=member.accent_color or discord.Color.default(),
-                    description=f"Bienvenue a <@{member.id}>, {f"invité.e par <@{inviter_id}>" if inviter_id is not None else ""} sur le discord de [Phoenix Legacy](https://phxlgc.com)!"
+                    description=self.t('invites.welcome_description', member.guild.id, member_id=member.id, inviter_part=inviter_part),
                 )
                 await announcement_channel.send(content=greeting_text, embed=embed)
 

--- a/cogs/locale/locale.py
+++ b/cogs/locale/locale.py
@@ -1,0 +1,41 @@
+import discord
+from discord import option
+from discord.ext import commands
+
+from src import FriendlyFire, BaseCog
+
+
+class Locale(BaseCog):
+    def __init__(self, bot: FriendlyFire):
+        super().__init__(bot, None)
+
+    localeGroup = discord.SlashCommandGroup(
+        name="locale",
+        description="Manage server language settings",
+        default_member_permissions=discord.Permissions(administrator=True),
+        contexts=[discord.InteractionContextType.guild],
+    )
+
+    async def _get_available_locales(self, ctx: discord.AutocompleteContext):
+        return self.bot.locale_manager.available_locales()
+
+    @localeGroup.command(name="set", description="Set the language for this server")
+    @option(name="language", description="Language code (e.g. en, fr)", required=True, autocomplete=_get_available_locales)
+    async def locale_set(self, ctx: discord.ApplicationContext, language: str):
+        await ctx.defer(ephemeral=True)
+        available = self.bot.locale_manager.available_locales()
+        if language not in available:
+            await ctx.respond(f"Unknown language `{language}`. Available: {', '.join(f'`{l}`' for l in available)}")
+            return
+        self.bot.locale_config.set('language', language, guild_id=ctx.guild_id)
+        await ctx.respond(f"Server language set to `{language}`.")
+
+    @localeGroup.command(name="get", description="Show the current language for this server")
+    async def locale_get(self, ctx: discord.ApplicationContext):
+        await ctx.defer(ephemeral=True)
+        lang = self.bot.locale_config.get('language', ctx.guild_id) or 'en'
+        await ctx.respond(f"Current language: `{lang}`.")
+
+
+def setup(bot):
+    bot.add_cog(Locale(bot))

--- a/cogs/starboard/starboard.py
+++ b/cogs/starboard/starboard.py
@@ -1,0 +1,140 @@
+from typing import TypedDict
+
+import discord
+from discord import option
+from discord.ext import commands
+from pymongo.asynchronous.collection import AsyncCollection
+
+from src import FriendlyFire, BaseCog
+
+
+class StarboardEntry(TypedDict):
+    original_message_id: str
+    starboard_message_id: str
+    channel_id: str
+    author_id: int
+
+
+class Starboard(BaseCog):
+    def __init__(self, bot: FriendlyFire):
+        super().__init__(bot, 'starboard', {
+            "minStars": 3,
+        })
+
+    starboardGroup = discord.SlashCommandGroup(
+        name="starboard",
+        description="Manage starboard settings",
+        default_member_permissions=discord.Permissions(administrator=True),
+        contexts=[discord.InteractionContextType.guild],
+    )
+
+    @starboardGroup.command(name="setchannel", description="Set the starboard channel")
+    @option(name="channel", description="Channel to post starred messages in", required=True, input_type=discord.SlashCommandOptionType.channel)
+    async def set_channel(self, ctx: discord.ApplicationContext, channel: discord.TextChannel):
+        await ctx.defer(ephemeral=True)
+        self.config.set('starboardChannel', str(channel.id), guild_id=ctx.guild_id)
+        await ctx.respond(f"Starboard channel set to {channel.mention}.")
+
+    @starboardGroup.command(name="setstars", description="Set the minimum number of ⭐ reactions to appear on the starboard")
+    @option(name="count", description="Minimum number of stars", required=True, input_type=int)
+    async def set_stars(self, ctx: discord.ApplicationContext, count: int):
+        await ctx.defer(ephemeral=True)
+        if count < 1:
+            await ctx.respond("Minimum stars must be at least 1.")
+            return
+        self.config.set('minStars', count, guild_id=ctx.guild_id)
+        await ctx.respond(f"Minimum stars set to {count}.")
+
+    def _star_count(self, message: discord.Message) -> int:
+        for reaction in message.reactions:
+            if str(reaction.emoji) == '⭐':
+                return reaction.count
+        return 0
+
+    def _build_embed(self, message: discord.Message, star_count: int) -> discord.Embed:
+        embed = discord.Embed(
+            description=message.content or "",
+            color=discord.Color.gold(),
+            timestamp=message.created_at,
+        )
+        embed.set_author(name=message.author.display_name, icon_url=message.author.display_avatar.url)
+        embed.add_field(name="Original", value=f"[Jump to message]({message.jump_url})")
+        if message.attachments:
+            embed.set_image(url=message.attachments[0].url)
+        embed.set_footer(text=f"⭐ {star_count} | #{message.channel.name}")
+        return embed
+
+    async def _handle_reaction_change(self, payload: discord.RawReactionActionEvent):
+        if str(payload.emoji) != '⭐' or payload.guild_id is None:
+            return
+
+        starboard_channel_id = self.config.get('starboardChannel', payload.guild_id)
+        if not starboard_channel_id:
+            return
+
+        if str(payload.channel_id) == str(starboard_channel_id):
+            return
+
+        channel = self.bot.get_channel(payload.channel_id)
+        if channel is None:
+            return
+
+        try:
+            message = await channel.fetch_message(payload.message_id)
+        except discord.NotFound:
+            return
+
+        star_count = self._star_count(message)
+        min_stars = self.config.get('minStars', payload.guild_id) or 3
+
+        collection: AsyncCollection[StarboardEntry] = await self.bot.mongo.get_collection(payload.guild_id, "starboard")
+        existing = await collection.find_one({"original_message_id": str(payload.message_id)})
+
+        starboard_channel = self.bot.get_channel(int(starboard_channel_id))
+        if starboard_channel is None:
+            return
+
+        if star_count < min_stars:
+            if existing:
+                try:
+                    sb_msg = await starboard_channel.fetch_message(int(existing['starboard_message_id']))
+                    await sb_msg.delete()
+                except discord.NotFound:
+                    pass
+                await collection.delete_one({"original_message_id": str(payload.message_id)})
+            return
+
+        embed = self._build_embed(message, star_count)
+        content = f"⭐ **{star_count}**"
+
+        if existing:
+            try:
+                sb_msg = await starboard_channel.fetch_message(int(existing['starboard_message_id']))
+                await sb_msg.edit(content=content, embed=embed)
+            except discord.NotFound:
+                sb_msg = await starboard_channel.send(content=content, embed=embed)
+                await collection.update_one(
+                    {"original_message_id": str(payload.message_id)},
+                    {"$set": {"starboard_message_id": str(sb_msg.id)}},
+                )
+        else:
+            sb_msg = await starboard_channel.send(content=content, embed=embed)
+            await collection.insert_one(StarboardEntry(
+                original_message_id=str(payload.message_id),
+                starboard_message_id=str(sb_msg.id),
+                channel_id=str(payload.channel_id),
+                author_id=payload.user_id,
+            ))
+            self.log(f"Posted message {payload.message_id} to starboard with {star_count} stars.")
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        await self._handle_reaction_change(payload)
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
+        await self._handle_reaction_change(payload)
+
+
+def setup(bot):
+    bot.add_cog(Starboard(bot))

--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -62,7 +62,7 @@ class Topic(BaseCog):
         embed = discord.Embed(
             title=f"{name} {type_descriptor['emoji']} {type_descriptor['text']}",
             color=color,
-            footer=discord.embeds.EmbedFooter(text="Clique sur ✅ pour t'abonner à ce topic"),
+            footer=discord.embeds.EmbedFooter(text=self.t('topic.subscribe_footer', ctx.guild_id)),
         )
 
         image_data = await self._fetch_image(image) if image else None
@@ -115,7 +115,7 @@ class Topic(BaseCog):
         embed = discord.Embed(
             title=f"{name} {type_descriptor['emoji']} {type_descriptor['text']}",
             color=color,
-            footer=discord.embeds.EmbedFooter(text="Clique sur ✅ pour t'abonner à ce topic"),
+            footer=discord.embeds.EmbedFooter(text=self.t('topic.subscribe_footer', ctx.guild_id)),
         )
 
         await role.edit(color=color)

--- a/config/locale.template.json
+++ b/config/locale.template.json
@@ -1,0 +1,10 @@
+{
+    "global": {
+        "language": "en"
+    },
+    "guilds": {
+        "123456789": {
+            "language": "fr"
+        }
+    }
+}

--- a/config/starboard.template.json
+++ b/config/starboard.template.json
@@ -1,0 +1,11 @@
+{
+    "global": {
+        "minStars": 3
+    },
+    "guilds": {
+        "123456789": {
+            "starboardChannel": "channel_id_here",
+            "minStars": 3
+        }
+    }
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,11 @@
+{
+    "invites": {
+        "welcome_title": "Welcome!",
+        "welcome_description": "Welcome <@{member_id}>{inviter_part} to the server!",
+        "invited_by": ", invited by <@{inviter_id}>",
+        "server_link_text": "the server"
+    },
+    "topic": {
+        "subscribe_footer": "Click ✅ to subscribe to this topic"
+    }
+}

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,0 +1,11 @@
+{
+    "invites": {
+        "welcome_title": "Bienvenue!",
+        "welcome_description": "Bienvenue a <@{member_id}>{inviter_part} sur le discord de [Phoenix Legacy](https://phxlgc.com)!",
+        "invited_by": ", invité.e par <@{inviter_id}>",
+        "server_link_text": "le serveur"
+    },
+    "topic": {
+        "subscribe_footer": "Clique sur ✅ pour t'abonner à ce topic"
+    }
+}

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,2 +1,3 @@
 from .bot import FriendlyFire
 from .cog import BaseCog
+from .locale import LocaleManager

--- a/src/bot.py
+++ b/src/bot.py
@@ -4,12 +4,20 @@ import traceback
 import discord
 from discord.ext import commands
 from src.mongo import Mongo
+from src.locale import LocaleManager
+from src.config import Config
 
 class FriendlyFire(commands.Bot):
     def __init__(self, mongo_uri: str = None):
         super().__init__(intents=discord.Intents.all())
         self.mongo = Mongo(mongo_uri)
         self._owner: discord.User = None
+        self.locale_manager = LocaleManager()
+        self.locale_config = Config('locale', {'language': 'en'})
+
+    def t(self, key: str, guild_id=None, **kwargs) -> str:
+        lang = self.locale_config.get('language', guild_id) or 'en'
+        return self.locale_manager.t(key, lang, **kwargs)
 
     async def on_ready(self):
         print(f'Logged in as {self.user.name} ({self.user.id})')

--- a/src/cog.py
+++ b/src/cog.py
@@ -11,6 +11,9 @@ class BaseCog(commands.Cog):
     def log(self, message: str):
         print(f'[{type(self).__name__}] {message}')
 
+    def t(self, key: str, guild_id=None, **kwargs) -> str:
+        return self.bot.t(key, guild_id, **kwargs)
+
     @commands.Cog.listener()
     async def on_ready(self):
         self.log('Module ready')

--- a/src/locale.py
+++ b/src/locale.py
@@ -1,0 +1,46 @@
+import json
+import os
+
+
+class LocaleManager:
+    def __init__(self, locales_dir: str = 'locales', default_locale: str = 'en'):
+        self.default_locale = default_locale
+        self._strings: dict[str, dict] = {}
+        self._load_all(locales_dir)
+
+    def _load_all(self, locales_dir: str):
+        if not os.path.isdir(locales_dir):
+            print(f'[Locale] Directory "{locales_dir}" not found, no locales loaded.')
+            return
+        for filename in os.listdir(locales_dir):
+            if filename.endswith('.json'):
+                locale = filename[:-5]
+                path = os.path.join(locales_dir, filename)
+                with open(path, 'r', encoding='utf-8') as f:
+                    self._strings[locale] = json.load(f)
+        print(f'[Locale] Loaded locales: {", ".join(self._strings.keys())}')
+
+    def available_locales(self) -> list[str]:
+        return list(self._strings.keys())
+
+    def t(self, key: str, locale: str = None, **kwargs) -> str:
+        locale = locale or self.default_locale
+        strings = self._strings.get(locale, {})
+
+        value = strings
+        for part in key.split('.'):
+            if isinstance(value, dict):
+                value = value.get(part)
+            else:
+                value = None
+                break
+
+        if value is None and locale != self.default_locale:
+            return self.t(key, self.default_locale, **kwargs)
+
+        if value is None:
+            return key
+
+        if kwargs:
+            value = value.format(**kwargs)
+        return value


### PR DESCRIPTION
## Summary

- **Starboard (closes #73):** New `cogs/starboard` cog that reposts messages to a `starboard` channel when they reach a configurable minimum number of ⭐ reactions. Star count on the reposted embed updates live as reactions change; the entry is removed if stars drop below the threshold. Adds `/starboard setchannel` and `/starboard setstars` admin commands, with settings stored per-guild via the existing `Config` system and starred message tracking in MongoDB.

- **Localisation (closes #72):** Lightweight `LocaleManager` (`src/locale.py`) that loads JSON files from `locales/`. English (`en`) ships as the default; French (`fr`) is bundled to preserve existing bot behaviour. `FriendlyFire.t()` and `BaseCog.t()` expose translations as a one-liner anywhere in the codebase. A new `cogs/locale` cog provides `/locale set <language>` and `/locale get` admin commands for per-guild language selection, persisted via `Config`. Existing hardcoded French strings in `invites` and `topic` cogs have been migrated to locale keys.

## Test plan

- [ ] `/starboard setchannel #channel` sets the starboard channel for the guild
- [ ] `/starboard setstars 5` updates the minimum star threshold
- [ ] Adding ⭐ reactions to a message posts/updates it in the starboard channel once the threshold is reached
- [ ] Removing stars below threshold deletes the starboard entry
- [ ] Messages in the starboard channel itself are not re-starred
- [ ] `/locale set fr` switches the guild to French; welcome embed and topic footer appear in French
- [ ] `/locale set en` switches back to English
- [ ] `/locale get` shows the current language
- [ ] Unknown language code returns a helpful error listing available options
- [ ] Adding a new `locales/xx.json` makes `xx` available in the autocomplete without code changes

https://claude.ai/code/session_01NaQKQEQa2oEPsyMnWFN9Dm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaQKQEQa2oEPsyMnWFN9Dm)_