### PR TITLE
fix: guard edit_topic against deleted channel and missing message

### DIFF
--- a/cogs/topic/topic.py
+++ b/cogs/topic/topic.py
@@ -105,7 +105,14 @@ class Topic(BaseCog):
         color = discord.Color(int(type_descriptor["color"], 16))
 
         channel = self.bot.get_channel(int(topic["channelId"]))
-        message = await channel.fetch_message(int(topic["messageId"]))
+        if channel is None:
+            await ctx.respond("The topic's channel no longer exists. Please delete and recreate the topic.")
+            return
+        try:
+            message = await channel.fetch_message(int(topic["messageId"]))
+        except discord.NotFound:
+            await ctx.respond("The topic's message no longer exists. Please delete and recreate the topic.")
+            return
 
         if name is None:
             name = topic["roleName"]


### PR DESCRIPTION
Fixes #77

## Summary

- `edit_topic` called `channel.fetch_message()` without first checking whether `get_channel()` returned `None`
- If the topic's channel has been deleted (or is not in the bot's cache), this crashes with `AttributeError: 'NoneType' object has no attribute 'fetch_message'`
- Also adds a `discord.NotFound` guard for the case where the channel exists but the embed message was deleted
- `delete_topic` in the same file already had both guards; `edit_topic` was the only command missing them

## Test plan

- [ ] Create a topic, delete its channel, then run `/topic edit` — should now respond with a clear error instead of crashing
- [ ] Create a topic, delete only its embed message (keep the channel), then run `/topic edit` — should respond with a clear error
- [ ] Normal `/topic edit` on a valid topic with an intact channel and message continues to work correctly

https://claude.ai/code/session_01D5n3kuVQgvXsn7UW8kabCb

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5n3kuVQgvXsn7UW8kabCb)_