### PR TITLE
fix: remove dead collection-None check and unused asyncio import in mongo.py

### DIFF
--- a/src/mongo.py
+++ b/src/mongo.py
@@ -1,6 +1,4 @@
-﻿import asyncio
 from pymongo import AsyncMongoClient
-from pymongo.asynchronous.collection import AsyncCollection
 
 
 class Mongo:
@@ -10,9 +8,4 @@ class Mongo:
 
     async def get_collection(self, guild_id: int, collection_name: str):
         database = self.client.get_database(str(guild_id))
-        collection = database[collection_name]
-
-        if collection is None:
-            collection = await database.create_collection(collection_name)
-
-        return collection
+        return database[collection_name]


### PR DESCRIPTION
Fixes #78

## Summary

- `database[collection_name]` in PyMongo **never returns `None`** — it always returns a `Collection` object, with the collection being created implicitly on first write
- The `if collection is None: await database.create_collection(...)` branch was permanently dead code that has never executed
- Also removes the `import asyncio` line which was unused throughout the file
- Simplifies `get_collection` to a two-liner

## Test plan

- [ ] Bot starts and all cogs load without errors
- [ ] MongoDB reads and writes (greetings, invites, topics, quotes) continue to work normally

https://claude.ai/code/session_01D5n3kuVQgvXsn7UW8kabCb

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5n3kuVQgvXsn7UW8kabCb)_