### PR TITLE
fix: skip non-cog entries when loading cogs (prevents __pycache__ crash)

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,8 @@ bot = FriendlyFire(mongo_uri=MONGO_URI)
 
 # load all cogs as extensions
 for cog in os.listdir('./cogs'):
-    bot.load_extension(f'cogs.{cog}.{cog}')
+    if os.path.isdir(f'./cogs/{cog}') and not cog.startswith('_'):
+        bot.load_extension(f'cogs.{cog}.{cog}')
 
 # start the bot
 bot.run(TOKEN)


### PR DESCRIPTION
Fixes #82

## Summary

- `os.listdir('./cogs')` returns all directory entries including `__pycache__`, which is created after the first run
- The loader attempted `bot.load_extension('cogs.__pycache__.__pycache__')`, raising an unhandled `ExtensionNotFound` and crashing the bot on any restart
- Added an `os.path.isdir` check and a `not cog.startswith('_')` guard so only real cog subdirectories are loaded

## Test plan

- [ ] Bot starts successfully on first run (no `__pycache__`)
- [ ] Bot starts successfully on subsequent runs (with `__pycache__` present)
- [ ] All four cogs (`invites`, `presence`, `quotes`, `topic`) load correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ne6zJrFd4vmeoZvMnV8KTU)_