### PR TITLE
fix: raise ClientError on non-200 response in generate_quote_image

### DIFF
--- a/cogs/quotes/quote_image.py
+++ b/cogs/quotes/quote_image.py
@@ -39,7 +39,7 @@ def _render(bg_data: bytes, quote: str, author: str, font_path: str) -> bytes:
     font_deco = ImageFont.truetype(font_path, 220)
 
     # Decorative opening quote mark (faint, top-left)
-    draw.text((50, -40), '\u201c', font=font_deco, fill=(255, 255, 255, 45))
+    draw.text((50, -40), '“', font=font_deco, fill=(255, 255, 255, 45))
 
     # Wrap and vertically center quote text
     lines = _wrap_text(draw, quote, font_quote, IMG_W - PADDING * 2)
@@ -54,7 +54,7 @@ def _render(bg_data: bytes, quote: str, author: str, font_path: str) -> bytes:
         y += line_h
 
     # Author centered near bottom
-    author_str = f'\u2014 {author}'
+    author_str = f'— {author}'
     ax = int((IMG_W - draw.textlength(author_str, font=font_author)) // 2)
     ay = IMG_H - 90
     draw.text((ax + 2, ay + 2), author_str, font=font_author, fill=(0, 0, 0, 180))
@@ -69,5 +69,7 @@ async def generate_quote_image(quote: str, author: str, font_path: str) -> bytes
     timeout = aiohttp.ClientTimeout(total=10)
     async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.get(f'https://picsum.photos/{IMG_W}/{IMG_H}', allow_redirects=True) as resp:
+            if resp.status != 200:
+                raise aiohttp.ClientError(f'picsum.photos returned HTTP {resp.status}')
             bg_data = await resp.read()
     return _render(bg_data, quote, author, font_path)


### PR DESCRIPTION
Fixes #83

## Summary

- `generate_quote_image` read the response body from `picsum.photos` without checking `resp.status`
- On a non-200 response (e.g. 429 Too Many Requests, 503), `bg_data` contained HTML/text rather than image bytes
- `_render` then called `Image.open(io.BytesIO(bg_data))`, raising `PIL.UnidentifiedImageError`
- Callers only catch `(aiohttp.ClientError, asyncio.TimeoutError)`, so the error escaped as an unhandled exception, making `/quote` show "Application did not respond"
- Fix: raise `aiohttp.ClientError` when the status is not 200, which the existing `except` blocks already handle correctly

## Test plan

- [ ] `/quote` returns a friendly "Failed to fetch background image" message when picsum.photos is unreachable or rate-limits
- [ ] `/quote` works normally under happy-path conditions

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ne6zJrFd4vmeoZvMnV8KTU)_