### PR TITLE
fix: rename refresh to _refresh_embed to avoid shadowing View.refresh

### DIFF
--- a/cogs/quotes/quotes_paginate_view.py
+++ b/cogs/quotes/quotes_paginate_view.py
@@ -60,7 +60,7 @@ class QuotesPaginateView(discord.ui.View):
             except discord.NotFound:
                 pass
 
-    async def refresh(self, interaction: discord.Interaction):
+    async def _refresh_embed(self, interaction: discord.Interaction):
         self.update_buttons()
         await interaction.response.edit_message(embed=self.get_embed(), view=self)
 
@@ -71,7 +71,7 @@ class QuotesPaginateView(discord.ui.View):
         await collection.update_one({'_id': quote['_id']}, {'$set': {'safe': True, 'checked': True}})
         quote['safe'] = True
         quote['checked'] = True
-        await self.refresh(interaction)
+        await self._refresh_embed(interaction)
 
     @discord.ui.button(label='Unsafe', style=ButtonStyle.secondary, row=0)
     async def unsafe_button(self, button: discord.ui.Button, interaction: discord.Interaction):
@@ -80,24 +80,24 @@ class QuotesPaginateView(discord.ui.View):
         await collection.update_one({'_id': quote['_id']}, {'$set': {'safe': False, 'checked': True}})
         quote['safe'] = False
         quote['checked'] = True
-        await self.refresh(interaction)
+        await self._refresh_embed(interaction)
 
     @discord.ui.button(label='Prev', style=ButtonStyle.gray, row=1)
     async def prev_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         self.current_id = (self.current_id - 1) % len(self.quotes)
         self.show_payload = False
-        await self.refresh(interaction)
+        await self._refresh_embed(interaction)
 
     @discord.ui.button(label='Next', style=ButtonStyle.gray, row=1)
     async def next_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         self.current_id = (self.current_id + 1) % len(self.quotes)
         self.show_payload = False
-        await self.refresh(interaction)
+        await self._refresh_embed(interaction)
 
     @discord.ui.button(label='Show Payload', style=ButtonStyle.gray, row=1)
     async def toggle_payload(self, button: discord.ui.Button, interaction: discord.Interaction):
         self.show_payload = not self.show_payload
-        await self.refresh(interaction)
+        await self._refresh_embed(interaction)
 
     @discord.ui.button(label='Delete', style=ButtonStyle.red, row=2)
     async def delete_button(self, button: discord.ui.Button, interaction: discord.Interaction):
@@ -114,4 +114,4 @@ class QuotesPaginateView(discord.ui.View):
         if self.current_id >= len(self.quotes):
             self.current_id = len(self.quotes) - 1
         self.show_payload = False
-        await self.refresh(interaction)
+        await self._refresh_embed(interaction)


### PR DESCRIPTION
Fixes #87

## Summary

- `discord.ui.View` has an internal synchronous `refresh(components)` method used by py-cord to rebuild button state after a component interaction
- `QuotesPaginateView` defined `async def refresh(self, interaction)` with the same name, shadowing it
- py-cord called our method with a `components` list as the `interaction` argument; the coroutine was created but never awaited, causing `RuntimeWarning: coroutine 'QuotesPaginateView.refresh' was never awaited` in the GC on every pagination button click
- Renames to `_refresh_embed` at the definition and all six call sites (`safe_button`, `unsafe_button`, `prev_button`, `next_button`, `toggle_payload`, `delete_button`)

This is the same fix that was prepared in PR #68 (closed without merging).

## Test plan

- [ ] Bot starts without `RuntimeWarning` about unawaited coroutine
- [ ] All quote pagination buttons (Safe, Unsafe, Prev, Next, Show Payload, Delete) correctly update the embed

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqiGCLRWbqT1S9P5hvXU6u)_