### PR TITLE
fix: replace deprecated guild_only=True with contexts in standalone slash commands

### DIFF
--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -51,7 +51,7 @@ class Invites(BaseCog):
             view=view
         )
 
-    @discord.slash_command(name="invite", description="Generates a temporary invite", default_member_permissions=discord.Permissions(administrator=True), guild_only=True)
+    @discord.slash_command(name="invite", description="Generates a temporary invite", default_member_permissions=discord.Permissions(administrator=True), contexts=[discord.InteractionContextType.guild])
     async def invite(self, ctx: discord.ApplicationContext):
         await ctx.defer(ephemeral=True)
 
@@ -69,7 +69,7 @@ class Invites(BaseCog):
         expiry_text = f", It will be valid until {format_dt(invite.expires_at)}" if invite.expires_at else " (permanent)"
         await ctx.respond(f"Here is your invite link: {invite.url}{expiry_text}.")
 
-    @discord.slash_command(name="test_join", description="Generates a temporary invite", default_member_permissions=discord.Permissions(administrator=True), guild_only=True)
+    @discord.slash_command(name="test_join", description="Generates a temporary invite", default_member_permissions=discord.Permissions(administrator=True), contexts=[discord.InteractionContextType.guild])
     @option(name="user", description="user to fake joining", required=True, input_type=discord.SlashCommandOptionType.user)
     async def test_join(self, ctx: discord.ApplicationContext, user: discord.User):
         await ctx.defer(ephemeral=True)

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -145,7 +145,7 @@ class Quotes(BaseCog):
         self.config.set('replyChannelId', str(channel.id), ctx.guild_id)
         await ctx.respond(f"Reply channel set to {channel.mention}")
 
-    @discord.slash_command(name="quote", description="Send a quote from the database.", guild_only=True)
+    @discord.slash_command(name="quote", description="Send a quote from the database.", contexts=[discord.InteractionContextType.guild])
     @discord.option(name="id", parameter_name="quote_id", description="Id of the quote to send", required=False, input_type=int)
     async def quote(self, ctx: discord.ApplicationContext, quote_id: int = None):
         reply_channel_id = self.config.get('replyChannelId', ctx.guild_id)
@@ -217,7 +217,7 @@ class Quotes(BaseCog):
         await ctx.respond(embed=view.get_embed(), view=view)
         view.message = await ctx.interaction.original_response()
 
-    @discord.slash_command(name="crawl-missing-quotes", description="Crawl the quote channel to backfill missing quotes.", default_member_permissions=discord.Permissions(administrator=True), guild_only=True)
+    @discord.slash_command(name="crawl-missing-quotes", description="Crawl the quote channel to backfill missing quotes.", default_member_permissions=discord.Permissions(administrator=True), contexts=[discord.InteractionContextType.guild])
     async def crawl_missing_quotes(self, ctx: discord.ApplicationContext):
         capture_channel_id = self.config.get('captureChannelId', ctx.guild_id)
         if not capture_channel_id or str(ctx.channel_id) != capture_channel_id:


### PR DESCRIPTION
Fixes #88

## Summary

- `guild_only=True` was deprecated in py-cord 2.6 in favour of `contexts=[discord.InteractionContextType.guild]`
- PR #70 replaced it in `SlashCommandGroup` definitions but missed four standalone `@discord.slash_command` decorators:
  - `/invite` and `/test_join` in `cogs/invites/invites.py`
  - `/quote` and `/crawl-missing-quotes` in `cogs/quotes/quotes.py`
- Each of these emits a deprecation warning on startup and on every command sync with Discord
- Replaces `guild_only=True` with `contexts=[discord.InteractionContextType.guild]` to match the pattern already used by the `SlashCommandGroup` definitions in the same files

## Test plan

- [ ] Bot starts without deprecation warnings about `guild_only`
- [ ] `/invite`, `/test_join`, `/quote`, and `/crawl-missing-quotes` remain guild-only and work normally

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqiGCLRWbqT1S9P5hvXU6u)_