### PR TITLE
fix: make vote duplicate check atomic via MongoDB filter

### DIFF
--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -92,17 +92,21 @@ class QuoteView(discord.ui.View):
 
     async def _vote(self, interaction: discord.Interaction, field: str, opposite_field: str):
         user_id = str(interaction.user.id)
-        if user_id in self.current_quote.get(field, []):
+        collection: AsyncCollection = await self.quotes_cog.bot.mongo.get_collection(self.guild_id, 'quotes')
+
+        # Atomic check-and-update: filter rejects the update if user already voted,
+        # so modified_count==0 is the reliable duplicate signal regardless of concurrency.
+        result = await collection.update_one(
+            {'_id': self.current_quote['_id'], field: {'$ne': user_id}},
+            {'$addToSet': {field: user_id}, '$pull': {opposite_field: user_id}},
+        )
+
+        if result.modified_count == 0:
             await interaction.response.send_message('You already voted on this quote.', ephemeral=True)
             return
 
-        collection: AsyncCollection = await self.quotes_cog.bot.mongo.get_collection(self.guild_id, 'quotes')
-        update: dict = {'$push': {field: user_id}}
         if user_id in self.current_quote.get(opposite_field, []):
-            update['$pull'] = {opposite_field: user_id}
             self.current_quote[opposite_field].remove(user_id)
-
-        await collection.update_one({'_id': self.current_quote['_id']}, update)
         self.current_quote.setdefault(field, []).append(user_id)
         self._remove_reroll()
         self._update_vote_buttons()


### PR DESCRIPTION
Closes #93

## Problem

`QuoteView._vote` checked for duplicate votes against the in-memory `self.current_quote` dict **before** any `await`, but only appended the user ID to that dict **after** two awaits (`get_collection` + `update_one`):

```python
if user_id in self.current_quote.get(field, []):   # check against local state
    ...return

collection = await self.quotes_cog.bot.mongo.get_collection(...)  # await 1 — event loop can switch here
...
await collection.update_one(...)                                   # await 2 — event loop can switch here
self.current_quote.setdefault(field, []).append(user_id)           # append happens last
```

A second interaction from the same user arriving during either await would find the local list unchanged, pass the duplicate check, and push an additional entry to the MongoDB vote array — allowing a user to vote twice on the same quote.

## Fix

Replace the local pre-check with an atomic MongoDB filter. `update_one` is called with `{field: {$ne: user_id}}` in the query filter so the update is only applied when the user hasn't already voted. `modified_count == 0` becomes the reliable duplicate signal, regardless of how many concurrent interactions are in flight.

`$addToSet` provides an additional database-level uniqueness guarantee as a safety net.

```python
result = await collection.update_one(
    {'_id': self.current_quote['_id'], field: {'$ne': user_id}},
    {'$addToSet': {field: user_id}, '$pull': {opposite_field: user_id}},
)
if result.modified_count == 0:
    await interaction.response.send_message('You already voted on this quote.', ephemeral=True)
    return
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01HuTYjxq6SioC4tfJYZrupG)_