### PR TITLE
fix: catch json.JSONDecodeError in Config.load to prevent startup crash on malformed config

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -52,3 +52,6 @@ class Config:
             template_hint = f' See {self.template_file} for reference.' if os.path.exists(self.template_file) else ''
             print(f'[Config] {self.config_file} not found, using defaults.{template_hint}')
             return {}
+        except json.JSONDecodeError as e:
+            print(f'[Config] {self.config_file} contains invalid JSON ({e}), using defaults.')
+            return {}


### PR DESCRIPTION
## Summary

Closes #95

- `src/config.py` `load()` only caught `FileNotFoundError`, leaving `json.JSONDecodeError` unhandled.
- A hand-edited config file with a JSON syntax error (trailing comma, missing brace, etc.) crashed the bot on startup with an unhelpful traceback pointing inside the standard library.
- This PR adds an `except json.JSONDecodeError` clause that logs a clear, actionable message identifying the bad file and falls back to defaults, keeping the bot running.

## Test plan

- [ ] Introduce a JSON syntax error in `config/presence.json` (e.g. trailing comma), start the bot, and confirm it logs `[Config] config/presence.json contains invalid JSON (...), using defaults.` and continues starting up normally.
- [ ] Confirm a valid config file still loads correctly with no change in behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGxKWBUZQW2K7uamZ3JukV)_