### PR TITLE
Fix Discord mention tags showing raw in quote images

### DIFF
--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -41,7 +41,7 @@ async def _resolve_discord_mentions(text: str, guild: discord.Guild) -> str:
             except (discord.NotFound, discord.HTTPException):
                 pass
         if member:
-            members[uid] = member.display_name
+            members[uid] = member.name
 
     return re.sub(r'<@!?(\d+)>', lambda m: members.get(int(m.group(1)), m.group(0)), text)
 

--- a/cogs/quotes/quotes.py
+++ b/cogs/quotes/quotes.py
@@ -17,6 +17,34 @@ from src import FriendlyFire, BaseCog
 QUOTE_REGEX = re.compile(r'\"(.+?)\"\s*-*\s*(.*)', re.MULTILINE | re.DOTALL)
 CONFIRMATION_COLOR = 0x2ea42a
 
+
+async def _resolve_discord_mentions(text: str, guild: discord.Guild) -> str:
+    """Replace raw Discord mention tags with human-readable names."""
+    def replace_role(match):
+        role = guild.get_role(int(match.group(1)))
+        return f'@{role.name}' if role else match.group(0)
+
+    def replace_channel(match):
+        channel = guild.get_channel(int(match.group(1)))
+        return f'#{channel.name}' if channel else match.group(0)
+
+    text = re.sub(r'<@&(\d+)>', replace_role, text)
+    text = re.sub(r'<#(\d+)>', replace_channel, text)
+
+    user_ids = {int(m.group(1)) for m in re.finditer(r'<@!?(\d+)>', text)}
+    members: dict[int, str] = {}
+    for uid in user_ids:
+        member = guild.get_member(uid)
+        if member is None:
+            try:
+                member = await guild.fetch_member(uid)
+            except (discord.NotFound, discord.HTTPException):
+                pass
+        if member:
+            members[uid] = member.display_name
+
+    return re.sub(r'<@!?(\d+)>', lambda m: members.get(int(m.group(1)), m.group(0)), text)
+
 class QuoteView(discord.ui.View):
     def __init__(self, quotes_cog, guild_id: int, current_idx: int, total: int, requester_id: int, quote: dict, notify: str = None):
         super().__init__(timeout=86400)
@@ -71,8 +99,11 @@ class QuoteView(discord.ui.View):
         self.current_idx, self.current_quote = random.choice(safe_quotes)
         self.total = len(all_quotes)
 
+        resolved_quote = await _resolve_discord_mentions(self.current_quote['quote'], interaction.guild)
+        resolved_author = await _resolve_discord_mentions(self.current_quote.get('author', ''), interaction.guild)
+
         try:
-            image_bytes = await generate_quote_image(self.current_quote['quote'], self.current_quote.get('author', ''), self.quotes_cog.config.get('fontPath'))
+            image_bytes = await generate_quote_image(resolved_quote, resolved_author, self.quotes_cog.config.get('fontPath'))
         except (aiohttp.ClientError, asyncio.TimeoutError):
             await interaction.response.send_message('Failed to fetch background image. Please try again.', ephemeral=True)
             return
@@ -178,8 +209,11 @@ class Quotes(BaseCog):
                 return
             idx, quote = random.choice(safe_quotes)
 
+        resolved_quote = await _resolve_discord_mentions(quote['quote'], ctx.guild)
+        resolved_author = await _resolve_discord_mentions(quote.get('author', ''), ctx.guild)
+
         try:
-            image_bytes = await generate_quote_image(quote['quote'], quote.get('author', ''), self.config.get('fontPath'))
+            image_bytes = await generate_quote_image(resolved_quote, resolved_author, self.config.get('fontPath'))
         except (aiohttp.ClientError, asyncio.TimeoutError):
             await ctx.respond('Failed to fetch background image. Please try again.', ephemeral=True)
             return
@@ -310,10 +344,12 @@ class Quotes(BaseCog):
                 await msg.delete()
                 break
 
+        display_author = await _resolve_discord_mentions(entry['author'], message.guild)
+        display_quote = await _resolve_discord_mentions(entry['quote'], message.guild)
         embed = discord.Embed(
             color=CONFIRMATION_COLOR,
-            title=entry['author'],
-            description=entry['quote'],
+            title=display_author,
+            description=display_quote,
             url=message.jump_url,
         )
         embed.set_footer(text=f'Saved by {entry["submitted_by"]}. Quote #{idx + 1}/{len(all_quotes)}')


### PR DESCRIPTION
## Summary

- Adds `_resolve_discord_mentions(text, guild)` helper that resolves `<@userid>`, `<#channelid>`, and `<@&roleid>` tags to human-readable display names
- Applies resolution before generating quote images (`/quote` command and Reroll button)
- Applies resolution to the capture confirmation embed shown in the quotes channel
- Raw tags are kept in the database; resolution happens at display time so names stay current

## Test plan

- [ ] Post a quote in the capture channel where the author field contains a user mention (e.g. `"Some quote" - @username <@123456>`) — confirm the confirmation embed shows the display name, not the raw tag
- [ ] Run `/quote` — confirm the generated image shows the display name in the attribution line
- [ ] Hit Reroll on a quote that has a mention in its author or body — confirm the new image also resolves the names
- [ ] Test with a channel mention `<#id>` and role mention `<@&id>` to confirm those resolve to `#channel-name` and `@role-name` respectively
- [ ] Test with an unknown/deleted user ID — confirm it falls back gracefully to the raw tag

https://claude.ai/code/session_01JjFYJj8eKBDDED553rfVz8

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjFYJj8eKBDDED553rfVz8)_