### PR TITLE
fix: Resolve invite tracking and greetings pagination issues

### DIFF
--- a/cogs/invites/greetings_view.py
+++ b/cogs/invites/greetings_view.py
@@ -1,4 +1,4 @@
-﻿from typing import TypedDict
+from typing import TypedDict
 
 import discord
 from discord import ButtonStyle
@@ -13,6 +13,7 @@ class PaginatorView(discord.ui.View):
         self.invites_cog = invites_cog
         self.pages = pages
         self.current_page = max(1, min(start_id, len(self.pages))) - 1
+        self.update_buttons()
 
     @staticmethod
     def greeting_to_embed(greeting: Greeting) -> discord.Embed:

--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -131,6 +131,10 @@ class Invites(BaseCog):
 
         # Retrieve inviter
         inviter_id = await self.retrieve_inviter_id(member)
+        inviter_name = None
+        if inviter_id is not None:
+            inviter = member.guild.get_member(inviter_id)
+            inviter_name = inviter.name if inviter else f"<unknown {inviter_id}>"
         
         # Send announcement
         announcement_channel_id = self.config.get('invitesChannel', member.guild.id)
@@ -141,9 +145,9 @@ class Invites(BaseCog):
                 greetings = await greetings_collection.find({}).to_list()
                 greeting_text = random.choice(greetings)['greeting'] if greetings else None
 
-                inviter_mention = f"invité.e par <@{inviter_id}>\n" if inviter_id is not None else ""
+                inviter_mention = f"invité.e par **@{inviter_name}**\n" if inviter_name is not None else ""
                 greeting_suffix = f"\n\n{greeting_text}" if greeting_text else ""
-                description = f"Bienvenue a <@{member.id}>, {inviter_mention}sur le discord de [Phoenix Legacy](https://phxlgc.com)!{greeting_suffix}"
+                description = f"Bienvenue a **@{member.name}**, {inviter_mention}sur le discord de [Phoenix Legacy](https://phxlgc.com)!{greeting_suffix}"
                 embed = discord.Embed(
                     title="Bienvenue!",
                     thumbnail=member.avatar.url if member.avatar else None,

--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -131,10 +131,6 @@ class Invites(BaseCog):
 
         # Retrieve inviter
         inviter_id = await self.retrieve_inviter_id(member)
-        inviter_name = None
-        if inviter_id is not None:
-            inviter = member.guild.get_member(inviter_id)
-            inviter_name = inviter.name if inviter else f"<unknown {inviter_id}>"
         
         # Send announcement
         announcement_channel_id = self.config.get('invitesChannel', member.guild.id)
@@ -145,16 +141,16 @@ class Invites(BaseCog):
                 greetings = await greetings_collection.find({}).to_list()
                 greeting_text = random.choice(greetings)['greeting'] if greetings else None
 
-                inviter_mention = f"invité.e par **@{inviter_name}**\n" if inviter_name is not None else ""
+                inviter_mention = f"invité.e par <@{inviter_id}>\n" if inviter_id is not None else ""
                 greeting_suffix = f"\n\n{greeting_text}" if greeting_text else ""
-                description = f"Bienvenue a **@{member.name}**, {inviter_mention}sur le discord de [Phoenix Legacy](https://phxlgc.com)!{greeting_suffix}"
+                description = f"Bienvenue a <@{member.id}>, {inviter_mention}sur le discord de [Phoenix Legacy](https://phxlgc.com)!{greeting_suffix}"
                 embed = discord.Embed(
                     title="Bienvenue!",
                     thumbnail=member.avatar.url if member.avatar else None,
                     color=member.accent_color or discord.Color.default(),
                     description=description,
                 )
-                await announcement_channel.send(embed=embed)
+                await announcement_channel.send(content=f"Bienvenue <@{member.id}>!", embed=embed)
 
     @commands.Cog.listener()
     async def on_ready(self):

--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -104,10 +104,10 @@ class Invites(BaseCog):
 
             self.log(f"{len(server_invites)} invites server-side, {len(recorded_invites)} invites bot-side.")
 
-            server_invites_map = {i.code: i for i in server_invites}
+            server_invites_set = {i.code for i in server_invites}
             for invite in recorded_invites:
                 code = invite['code']
-                if code not in server_invites_map:
+                if code not in server_invites_set:
                     # Invite disappeared from server — if it hasn't expired it was consumed
                     expires = invite.get('expires')
                     if expires is None or expires > datetime.datetime.now().timestamp():

--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -80,6 +80,39 @@ class Invites(BaseCog):
         await self.on_member_join(member)
         await ctx.respond("test_join succeeded!")
 
+    async def retrieve_inviter_id(self, member: discord.Member):
+        try:
+            # Server-side invites
+            server_invites = await member.guild.invites()
+            # Bot-side invites
+            collection: AsyncCollection[InviteEntry] = await self.bot.mongo.get_collection(member.guild.id, "invites")
+            saved_invites = await collection.find({}).to_list()
+
+            self.log(f"{len(server_invites)} invites server-side, {len(saved_invites)} invites bot-side.")
+
+            server_invites_set = {i.code for i in server_invites}
+            for invite in saved_invites:
+                code = invite['code']
+                if code not in server_invites_set:
+                    # Invite disappeared from server — if it hasn't expired it was consumed
+                    expires = invite.get('expires')
+                    if expires is None or expires > datetime.datetime.now().timestamp():
+                        inviter = member.guild.get_member(invite['author_id'])
+                        inviter_name = inviter.name if inviter else f"<unknown {invite['author_id']}>"
+                        self.log(f"{member.name} joined \"{member.guild.name}\" using one-time invite {code} by {inviter_name}")
+                        await collection.delete_one({"code": code})
+                        return invite['author_id']
+                    else:
+                        # Clean up expired invite code from MongoDB on-the-fly
+                        await collection.delete_one({"code": code})
+
+        except discord.Forbidden:
+            self.log("Missing MANAGE_GUILD permission, skipping invite tracking.")
+
+        self.log(f"{member.name} joined using unknown invite code.")
+        return None
+
+
     @commands.Cog.listener()
     async def on_member_join(self, member: discord.Member):
         # Add default role
@@ -96,36 +129,10 @@ class Invites(BaseCog):
                 except discord.HTTPException as e:
                     self.log(f"HTTPException while adding role: {e}")
 
-        inviter_id = None
-        try:
-            server_invites = await member.guild.invites()
-            collection: AsyncCollection[InviteEntry] = await self.bot.mongo.get_collection(member.guild.id, "invites")
-            recorded_invites = await collection.find({}).to_list()
-
-            self.log(f"{len(server_invites)} invites server-side, {len(recorded_invites)} invites bot-side.")
-
-            server_invites_set = {i.code for i in server_invites}
-            for invite in recorded_invites:
-                code = invite['code']
-                if code not in server_invites_set:
-                    # Invite disappeared from server — if it hasn't expired it was consumed
-                    expires = invite.get('expires')
-                    if expires is None or expires > datetime.datetime.now().timestamp():
-                        inviter = member.guild.get_member(invite['author_id'])
-                        inviter_name = inviter.name if inviter else f"<unknown {invite['author_id']}>"
-                        self.log(f"{member.name} joined \"{member.guild.name}\" using one-time invite {code} by {inviter_name}")
-                        inviter_id = invite['author_id']
-                        await collection.delete_one({"code": code})
-                        break
-                    else:
-                        # Clean up expired invite code from MongoDB on-the-fly
-                        await collection.delete_one({"code": code})
-        except discord.Forbidden:
-            self.log("Missing MANAGE_GUILD permission, skipping invite tracking.")
-
-        if inviter_id is None:
-            self.log(f"{member.name} joined using unknown invite code.")
-
+        # Retrieve inviter
+        inviter_id = await self.retrieve_inviter_id(member)
+        
+        # Send announcement
         announcement_channel_id = self.config.get('invitesChannel', member.guild.id)
         if announcement_channel_id:
             announcement_channel = member.guild.get_channel(int(announcement_channel_id))

--- a/cogs/invites/invites.py
+++ b/cogs/invites/invites.py
@@ -56,9 +56,9 @@ class Invites(BaseCog):
         await ctx.defer(ephemeral=True)
 
         author = ctx.author
-        invite_max_age = self.config.get('inviteMaxAge')
+        invite_max_age = self.config.get('inviteMaxAge', ctx.guild_id)
 
-        invite = await ctx.channel.create_invite(temporary=True, max_age=invite_max_age)
+        invite = await ctx.channel.create_invite(temporary=True, max_age=invite_max_age, max_uses=1)
         invite_entry = InviteEntry(
             author_id=author.id,
             code=invite.code,
@@ -69,7 +69,7 @@ class Invites(BaseCog):
         expiry_text = f", It will be valid until {format_dt(invite.expires_at)}" if invite.expires_at else " (permanent)"
         await ctx.respond(f"Here is your invite link: {invite.url}{expiry_text}.")
 
-    @discord.slash_command(name="test_join", description="Generates a temporary invite", default_member_permissions=discord.Permissions(administrator=True), contexts=[discord.InteractionContextType.guild])
+    @discord.slash_command(name="test_join", description="Fakes a member joining the server to test greetings and roles", default_member_permissions=discord.Permissions(administrator=True), contexts=[discord.InteractionContextType.guild])
     @option(name="user", description="user to fake joining", required=True, input_type=discord.SlashCommandOptionType.user)
     async def test_join(self, ctx: discord.ApplicationContext, user: discord.User):
         await ctx.defer(ephemeral=True)
@@ -89,7 +89,12 @@ class Invites(BaseCog):
             if role_to_add is None:
                 self.log("no role found, ignoring for new member.")
             else:
-                await member.add_roles(role_to_add)
+                try:
+                    await member.add_roles(role_to_add)
+                except discord.Forbidden:
+                    self.log(f"Failed to add role {role_to_add.name} due to missing permissions.")
+                except discord.HTTPException as e:
+                    self.log(f"HTTPException while adding role: {e}")
 
         inviter_id = None
         try:
@@ -112,6 +117,9 @@ class Invites(BaseCog):
                         inviter_id = invite['author_id']
                         await collection.delete_one({"code": code})
                         break
+                    else:
+                        # Clean up expired invite code from MongoDB on-the-fly
+                        await collection.delete_one({"code": code})
         except discord.Forbidden:
             self.log("Missing MANAGE_GUILD permission, skipping invite tracking.")
 


### PR DESCRIPTION
This PR resolves multiple issues in the invites system:

1. **Invite Creation is not One-Time**: Sets max_uses=1 in create_invite to enable tracking when members join.
2. **Missing Guild Scope config**: Passes ctx.guild_id to inviteMaxAge configuration lookup.
3. **Paginator View Button State**: Initializes button state correctly by calling self.update_buttons() in PaginatorView.__init__.
4. **Role Assignment Exception Handling**: Catches discord.Forbidden and discord.HTTPException during role assignment on join to prevent listener crashes.
5. **On-the-fly Database Cleanup**: Purges expired database invite entries dynamically on join.